### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/developer/api-examples.md
+++ b/docs/developer/api-examples.md
@@ -402,7 +402,7 @@ Retrieve fibers claimed by non-archived splice plans on a closure device. Used b
 GET /api/plugins/fms/closures/{device_id}/fiber-claims/?exclude_plan={plan_id}
 ```
 
-The `exclude_plan` query parameter is optional — when provided, entries from that plan are excluded (typically the plan currently being edited).
+The `exclude_plan` query parameter is optional -- when provided, entries from that plan are excluded (typically the plan currently being edited).
 
 **curl**
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -84,7 +84,7 @@ Created automatically by `FiberCable._instantiate_components()` when a new
 | Model | Purpose |
 |-------|---------|
 | `SpliceProject` | Groups related splice plans for project-level organization. |
-| `SplicePlan` | A splice plan for a specific closure (`dcim.Device`, ForeignKey — multiple plans per closure allowed). Tracks diff staleness for cache invalidation. Status follows a four-state FSM: `draft` → `pending_approval` → `approved` → `archived`. Stores `submitted_by` (FK to `auth.User`). Enforces fiber exclusivity: each `FrontPort` may appear in at most one approved plan at a time. |
+| `SplicePlan` | A splice plan for a specific closure (`dcim.Device`, ForeignKey -- multiple plans per closure allowed). Tracks diff staleness for cache invalidation. Status follows a four-state FSM: `draft` -> `pending_approval` -> `approved` -> `archived`. Stores `submitted_by` (FK to `auth.User`). Enforces fiber exclusivity: each `FrontPort` may appear in at most one approved plan at a time. |
 | `SplicePlanEntry` | Maps one `dcim.FrontPort` (fiber_a) to another `dcim.FrontPort` (fiber_b), representing a planned splice. Includes a `change_note` field for per-entry annotations. |
 | `ClosureCableEntry` | Records which `FiberCable` instances enter a closure (`dcim.Device`). |
 | `SlackLoop` | Tracks slack loop storage at a closure. |
@@ -104,17 +104,17 @@ Created automatically by `FiberCable._instantiate_components()` when a new
 A `SplicePlan` moves through four states:
 
 ```
-draft  →  pending_approval  →  approved  →  archived
-  ↑              |
-  └──────────────┘  (rejection / reset to draft)
+draft  ->  pending_approval  ->  approved  ->  archived
+  ^              |
+  +--------------+  (rejection / reset to draft)
 ```
 
 | Transition | Meaning |
 |------------|---------|
-| `draft` → `pending_approval` | Submitter requests review; `submitted_by` is recorded. |
-| `pending_approval` → `approved` | Reviewer approves the plan; diff may now be applied. |
-| `pending_approval` → `draft` | Reviewer rejects or submitter retracts; plan is editable again. |
-| `approved` → `archived` | Plan has been applied and is no longer active. |
+| `draft` -> `pending_approval` | Submitter requests review; `submitted_by` is recorded. |
+| `pending_approval` -> `approved` | Reviewer approves the plan; diff may now be applied. |
+| `pending_approval` -> `draft` | Reviewer rejects or submitter retracts; plan is editable again. |
+| `approved` -> `archived` | Plan has been applied and is no longer active. |
 
 ### Enforcement Points
 

--- a/docs/developer/style-guide.md
+++ b/docs/developer/style-guide.md
@@ -1,8 +1,8 @@
-# FMS Visual Component Library — Style Guide
+# FMS Visual Component Library -- Style Guide
 
 ## 1. Overview
 
-The FMS component library (`fms-components.css`) provides shared UI primitives for all FMS visualization views: splice editors, wavelength planners, cable maps. It is **not** a full design system — it covers the specific patterns that appear across FMS canvases and panels.
+The FMS component library (`fms-components.css`) provides shared UI primitives for all FMS visualization views: splice editors, wavelength planners, cable maps. It is **not** a full design system -- it covers the specific patterns that appear across FMS canvases and panels.
 
 **Files:**
 - CSS: `netbox_fms/static/netbox_fms/css/fms-components.css`
@@ -29,13 +29,13 @@ Load the stylesheet in your template:
 <link rel="stylesheet" href="{% static 'netbox_fms/css/fms-components.css' %}">
 ```
 
-The component root reads `data-bs-theme` from a parent element to switch between dark and light palettes automatically — no extra JS needed.
+The component root reads `data-bs-theme` from a parent element to switch between dark and light palettes automatically -- no extra JS needed.
 
 ---
 
 ## 3. Color Palette
 
-All colors are defined as CSS custom properties on `.fms-component`. Never use hex values directly — always reference these variables.
+All colors are defined as CSS custom properties on `.fms-component`. Never use hex values directly -- always reference these variables.
 
 | Variable | Purpose |
 |---|---|
@@ -77,13 +77,13 @@ Use badges to show status inline with text. They are small (9px, uppercase) and 
 <span class="fms-badge fms-badge--protected">Protected</span>
 ```
 
-Do not use badges for counts or non-status information — use plain text for those.
+Do not use badges for counts or non-status information -- use plain text for those.
 
 ---
 
 ## 5. Legend (`.fms-legend`)
 
-The legend is an absolutely-positioned overlay anchored to the **bottom-left** of the canvas container. It collapses **downward** — the bottom edge stays fixed and the content shrinks into a small pill-shaped bar at the bottom corner.
+The legend is an absolutely-positioned overlay anchored to the **bottom-left** of the canvas container. It collapses **downward** -- the bottom edge stays fixed and the content shrinks into a small pill-shaped bar at the bottom corner.
 
 **Rules:**
 - Only include items that are currently visible on the canvas. If a filter hides all spliced strands, remove the "Spliced" entry from the legend. Rebuild on every render.
@@ -122,7 +122,7 @@ legend.destroy();
   <div class="fms-legend" id="my-legend">
     <div class="fms-legend__header">
       <span class="fms-legend__title">Legend</span>
-      <button class="fms-legend__toggle" aria-label="Toggle legend">▼</button>
+      <button class="fms-legend__toggle" aria-label="Toggle legend">v</button>
     </div>
     <div class="fms-legend__body">
       <div class="fms-legend__section">
@@ -141,7 +141,7 @@ legend.destroy();
 </div>
 ```
 
-The `data-collapsed` attribute is managed by `FmsLegend.toggle()`. When collapsed, the legend shrinks to a 24px pill showing "Legend ▲". When expanded, content grows upward from the bottom edge, toggle shows "▼".
+The `data-collapsed` attribute is managed by `FmsLegend.toggle()`. When collapsed, the legend shrinks to a 24px pill showing "Legend ^". When expanded, content grows upward from the bottom edge, toggle shows "v".
 
 ---
 
@@ -263,7 +263,7 @@ The toolbar sits above the canvas, below any page heading. It wraps at narrow wi
   <div class="fms-toolbar__spacer"></div>
 
   <!-- Search -->
-  <input class="fms-search" type="search" placeholder="Search…" aria-label="Search strands">
+  <input class="fms-search" type="search" placeholder="Search..." aria-label="Search strands">
 
 </div>
 ```
@@ -280,7 +280,7 @@ A slim (28px) bar pinned to the bottom of the canvas. Surfaces aggregate counts.
 
 **Stat ordering:** Essential counts left (total strands, active circuits), secondary/contextual counts right.
 
-Mark the most important stats with `fms-stat--essential` — these remain visible on mobile when non-essential stats are hidden.
+Mark the most important stats with `fms-stat--essential` -- these remain visible on mobile when non-essential stats are hidden.
 
 ```html
 <div class="fms-stats-bar fms-component">
@@ -289,11 +289,11 @@ Mark the most important stats with `fms-stat--essential` — these remain visibl
     <span class="fms-stat fms-stat--essential">
       <span class="fms-stat__label">Strands:</span> 144
     </span>
-    <span class="fms-stats-bar__dot" aria-hidden="true">·</span>
+    <span class="fms-stats-bar__dot" aria-hidden="true">.</span>
     <span class="fms-stat fms-stat--live">
       <span class="fms-stat__label">Live:</span> 88
     </span>
-    <span class="fms-stats-bar__dot" aria-hidden="true">·</span>
+    <span class="fms-stats-bar__dot" aria-hidden="true">.</span>
     <span class="fms-stat fms-stat--planned">
       <span class="fms-stat__label">Planned:</span> 12
     </span>
@@ -327,7 +327,7 @@ statsBar.update({
 statsBar.setMessage('Changes saved.', 3000);
 ```
 
-**Messages:** Use `setMessage()` for status updates — they appear on the right side alongside the plan badge and auto-clear. The left side (counts) is never replaced. Do not use alerts or toasts for minor status updates from canvas actions.
+**Messages:** Use `setMessage()` for status updates -- they appear on the right side alongside the plan badge and auto-clear. The left side (counts) is never replaced. Do not use alerts or toasts for minor status updates from canvas actions.
 
 ---
 
@@ -363,8 +363,8 @@ The library automatically responds to Bootstrap's `data-bs-theme` attribute. No 
 | Breakpoint | Width | Behavior |
 |---|---|---|
 | Desktop | > 991px | Full layout, panel slides in from right |
-| Tablet | ≤ 991px | Panel overlays canvas (absolute, full height, shadow) |
-| Mobile | ≤ 767px | Panel becomes bottom sheet (50vh max), toolbar compacts, legend hidden, non-essential stats hidden |
+| Tablet | <= 991px | Panel overlays canvas (absolute, full height, shadow) |
+| Mobile | <= 767px | Panel becomes bottom sheet (50vh max), toolbar compacts, legend hidden, non-essential stats hidden |
 
 ### Component behavior at each breakpoint
 
@@ -389,7 +389,7 @@ The library automatically responds to Bootstrap's `data-bs-theme` attribute. No 
 
 ### Touch targets
 
-All interactive elements must have a minimum tap target of **44×44px**, even if the visual element is smaller. Use padding to expand the hit area without changing the visual size.
+All interactive elements must have a minimum tap target of **44x44px**, even if the visual element is smaller. Use padding to expand the hit area without changing the visual size.
 
 ```css
 /* Expanding a small button's hit area */
@@ -421,8 +421,8 @@ Every interactive element must have a visible focus ring. The library provides `
 
 ### Keyboard navigation
 
-- **Escape** — close the open detail panel.
-- **Tab** — move through toolbar controls, close button, and panel rows in DOM order.
+- **Escape** -- close the open detail panel.
+- **Tab** -- move through toolbar controls, close button, and panel rows in DOM order.
 - Pill groups should support **Left/Right arrow** keys to move between pills in the group (implement with a `keydown` handler; the CSS does not do this automatically).
 
 ---

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,54 +1,142 @@
 # Configuration
 
-## Plugin Settings
+NetBox FMS works out of the box with no required configuration. This page
+covers the optional settings, the permission model, optional integration
+points, and the runtime side effects of installing the plugin.
 
-The current release (v0.1.0) ships with no custom plugin settings. The default configuration is empty:
+## Plugin settings
+
+The current release ships with no required entries in `PLUGINS_CONFIG`:
 
 ```python
 PLUGINS_CONFIG = {
-    'netbox_fms': {},
+    "netbox_fms": {},
 }
 ```
 
-No additional entries in `PLUGINS_CONFIG` are required. Future releases may introduce configurable options here.
+`PluginConfig.default_settings` is intentionally empty. Future releases that
+introduce configurable behavior will document any new keys here.
+
+## What `ready()` does at startup
+
+When NetBox loads the plugin, `NetBoxFMSConfig.ready()` performs four actions:
+
+1. **Patches the cable-profile registry** to register custom 24, 48, 72, 96,
+   144, 216, 288, and 432 strand profiles plus trunk profiles. NetBox does
+   not yet expose a public API for plugin-defined cable profiles
+   (see [netbox#21663](https://github.com/netbox-community/netbox/issues/21663)),
+   so the registration uses a monkey-patch in `monkey_patches.py`.
+2. **Connects signal handlers** that keep splice plan diffs fresh and block
+   out-of-band edits to FMS-managed `PortMapping` rows. See
+   [signals](../developer/architecture.md#signal-handlers).
+3. **Connects the counter cache** for `FiberCableType` so list views can
+   display the instance count without an extra query.
+4. **Registers map layers** with `netbox-pathways`, if it is installed:
+   `fms_splice_closures` and `fms_slack_loops`. The integration is best-effort
+   and silently skipped when `netbox-pathways` is not present.
+
+None of these are configurable, but they are useful to know if you are
+debugging plugin startup.
 
 ## Permissions
 
-NetBox FMS follows Django's standard permission system. Each model exposes four permissions: **view**, **add**, **change**, and **delete**. Assign these permissions to users or groups to control access.
+NetBox FMS uses Django's standard permission system. Every model exposes the
+four CRUD permissions (`view`, `add`, `change`, `delete`); `SplicePlan` adds
+one custom permission, `approve_spliceplan`, that gates the approval workflow.
 
-### Key Permission Names
+### Cable types and instances
 
-**Fiber Cable Types and Cables**
+| Permission                                  | Description                                |
+| ------------------------------------------- | ------------------------------------------ |
+| `netbox_fms.{view,add,change,delete}_fibercabletype`         | Manage cable type blueprints               |
+| `netbox_fms.{view,add,change,delete}_buffertubetemplate`     | Manage buffer tube templates               |
+| `netbox_fms.{view,add,change,delete}_ribbontemplate`         | Manage ribbon templates                    |
+| `netbox_fms.{view,add,change,delete}_cableelementtemplate`   | Manage non-fiber element templates         |
+| `netbox_fms.{view,add,change,delete}_fibercable`             | Manage cable instances                     |
+| `netbox_fms.{view,add,change,delete}_buffertube`             | Manage buffer tube instances (rare)        |
+| `netbox_fms.{view,add,change,delete}_ribbon`                 | Manage ribbon instances (rare)             |
+| `netbox_fms.{view,add,change,delete}_fiberstrand`            | Manage fiber strand instances (rare)      |
+| `netbox_fms.{view,add,change,delete}_cableelement`           | Manage cable element instances (rare)      |
 
-| Permission | Description |
-|---|---|
-| `netbox_fms.view_fibercabletype` | View fiber cable type definitions |
-| `netbox_fms.add_fibercabletype` | Create new fiber cable types |
-| `netbox_fms.change_fibercabletype` | Modify existing fiber cable types |
-| `netbox_fms.delete_fibercabletype` | Delete fiber cable types |
-| `netbox_fms.view_fibercable` | View fiber cable instances |
-| `netbox_fms.add_fibercable` | Create new fiber cables |
-| `netbox_fms.change_fibercable` | Modify existing fiber cables |
-| `netbox_fms.delete_fibercable` | Delete fiber cables |
+Most users do not need write access to the instance-level component models
+(buffer tubes, ribbons, strands, cable elements). The plugin creates and
+maintains them automatically when a `FiberCable` is saved.
 
-**Splice Planning**
+### Splice planning
 
-| Permission | Description |
-|---|---|
-| `netbox_fms.view_spliceproject` | View splice projects |
-| `netbox_fms.add_spliceproject` | Create splice projects |
-| `netbox_fms.view_spliceplan` | View splice plans |
-| `netbox_fms.add_spliceplan` | Create splice plans |
+| Permission                                                 | Description                                                            |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `netbox_fms.{view,add,change,delete}_spliceproject`        | Manage splice projects                                                 |
+| `netbox_fms.{view,add,change,delete}_spliceplan`           | Manage splice plans                                                    |
+| `netbox_fms.approve_spliceplan`                            | Approve, reject, reopen, or archive a non-draft plan                   |
+| `netbox_fms.{view,add,change,delete}_spliceplanentry`      | Manage individual splice plan entries                                  |
+| `netbox_fms.{view,add,change,delete}_closurecableentry`    | Manage gland labels for cables entering a closure                      |
+| `netbox_fms.{view,add,change,delete}_trayprofile`          | Mark a `dcim.ModuleType` as a splice tray or express basket            |
+| `netbox_fms.{view,add,change,delete}_tubeassignment`       | Assign buffer tubes to splice trays inside a closure                   |
 
-**Fiber Circuits**
+The `change_spliceplan` permission lets a user submit a draft plan and make
+edits, but it does not let them approve the plan once it is in
+`pending_approval`. Reserve `approve_spliceplan` for leads, network engineers,
+or anyone responsible for validating splice designs before they are applied.
 
-| Permission | Description |
-|---|---|
-| `netbox_fms.view_fibercircuit` | View fiber circuits |
-| `netbox_fms.add_fibercircuit` | Create fiber circuits |
-| `netbox_fms.change_fibercircuit` | Modify fiber circuits |
-| `netbox_fms.delete_fibercircuit` | Delete fiber circuits |
+### Fiber circuits
 
-### Assigning Permissions
+| Permission                                                | Description                              |
+| --------------------------------------------------------- | ---------------------------------------- |
+| `netbox_fms.{view,add,change,delete}_fibercircuit`        | Manage fiber circuits                    |
+| `netbox_fms.{view,add,change,delete}_fibercircuitpath`    | Manage individual fiber circuit paths    |
 
-Permissions can be assigned through the NetBox admin interface under **Admin > Permissions**, or programmatically via the NetBox REST API. Create a permission object, associate it with the relevant actions and object types, and assign it to the appropriate users or groups.
+`FiberCircuitNode` is a relational index used internally by the trace engine
+and circuit-protection checks. It does not have its own UI, but the standard
+Django auto-generated permissions exist if needed.
+
+### Operational metadata
+
+| Permission                                              | Description                                  |
+| ------------------------------------------------------- | -------------------------------------------- |
+| `netbox_fms.{view,add,change,delete}_slackloop`         | Manage slack loop records                    |
+
+### Assigning permissions
+
+Permissions are assigned through standard NetBox flows. The most common
+patterns are:
+
+- **Admin > Users > Permissions** in the UI.
+- **`/api/users/permissions/`** in the REST API.
+- A constraint-based permission with an object filter (for example, restrict
+  approval to plans owned by a specific tenant or located on closures inside a
+  specific site group).
+
+`approve_spliceplan` is enforced both by API view permissions and by model
+`clean()` validation, so granting it via a constrained permission also
+constrains the action.
+
+## Optional integrations
+
+### netbox-pathways (map layers)
+
+If `netbox-pathways` is installed, FMS automatically registers two map layers
+during startup:
+
+| Layer name              | Geometry | Source data                                              |
+| ----------------------- | -------- | -------------------------------------------------------- |
+| `fms_splice_closures`   | Point    | `dcim.Device` instances that have at least one `SplicePlan` |
+| `fms_slack_loops`       | Point    | `SlackLoop` instances                                    |
+
+Both layers are placed in the `Fiber Management` group on the layer toolbar.
+No configuration is needed; the registration is silently skipped if the
+import of `netbox_pathways.registry` fails.
+
+### Cable profiles (NetBox core)
+
+The plugin's cable profile registrations make NetBox's strand-level cable
+trace work for high-count fiber. See
+[Cable Profiles](../reference/cable-profiles.md) for the full list and the
+upstream issue tracking the migration to a public API.
+
+## Disabling features
+
+There is currently no flag for disabling any of the runtime side effects.
+If you need to skip the cable-profile patching (for example, while testing
+upstream NetBox changes), the cleanest path is to remove `netbox_fms` from
+`PLUGINS` for that environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,83 @@
-# NetBox FMS — Fiber Management System
+# NetBox FMS - Fiber Management System
 
 Fiber cable management, splice planning, and circuit provisioning for NetBox.
 
-**Version:** 0.1.0 | **Requires:** NetBox 4.5+ | **Python:** 3.12+
+**Version:** 0.1.0  |  **Requires:** NetBox 4.5+  |  **Python:** 3.12+
 
 ---
 
-## Feature Highlights
+## What it does
 
-- **Cable type blueprints with auto-instantiation** — Define fiber cable construction once as a FiberCableType, then create instances that automatically populate components, following NetBox's Device/DeviceType pattern.
-- **Four construction cases** — Model loose tube, ribbon-in-tube, central-core ribbon, and tight buffer cable designs with full template-driven instantiation.
-- **Splice planning with diff computation and draw.io export** — Build splice plans that map strand-to-strand connections, compute diffs against existing plans, and export diagrams for field crews.
-- **Fiber circuit provisioning with DAG-based pathfinding** — Provision end-to-end fiber circuits across your infrastructure using directed acyclic graph traversal for optimal path selection.
-- **Device fiber overview with closure management** — View all fiber connections on a device at a glance and manage splice closures with tray and group organization.
+NetBox FMS extends NetBox with the data model and tooling needed to track real
+fiber plant: outside-plant trunks, splice closures, fiber circuits, and the
+day-to-day work of moving glass around. It plugs into NetBox's existing
+`dcim.Cable` / `FrontPort` / `RearPort` graph rather than replacing it, so the
+trace algorithm, REST API, GraphQL schema, change log, and permission system
+all work the same way they do for the rest of NetBox.
+
+The plugin focuses on four problems:
+
+- **Cable construction modeling.** Define a fiber cable product once as a
+  blueprint (`FiberCableType`), then auto-instantiate buffer tubes, ribbons,
+  strands, and non-fiber elements every time you install that cable.
+- **Splice planning with review.** Plan splice work in `draft`, route it
+  through a review gate (`pending_approval` -> `approved`), and apply
+  approved plans atomically per closure.
+- **Fiber circuit provisioning.** Discover candidate paths between two devices
+  via DAG-based pathfinding and create end-to-end circuits with traceable hops.
+- **Operational metadata.** Slack loops, gland labels, tube-to-tray
+  assignments, and a per-device fiber overview tab.
+
+## Feature highlights
+
+- **Type/Instance pattern.** `FiberCableType` is a blueprint;
+  `FiberCable` is an instance. On creation, the instance auto-instantiates
+  components from the type's templates following the same shape NetBox uses
+  for `DeviceType` / `Device`.
+- **Four construction cases.** Loose tube, ribbon-in-tube, central-core
+  ribbon, and tight buffer. The case is determined entirely by which
+  templates are attached to the type; no flag is needed.
+- **EIA-598 colors.** Strands and tubes are colored automatically by position,
+  cycling every 12. No manual color entry.
+- **Splice plan FSM.** `draft` -> `pending_approval` -> `approved` ->
+  `archived`. Multiple plans can target the same closure in parallel; fiber
+  exclusivity prevents collisions. Approval requires the
+  `approve_spliceplan` permission.
+- **Splice editor.** TypeScript/D3 visual editor at the device level. Drag to
+  splice, click to remove, ghost lines for fibers claimed by other plans,
+  read-only mode for non-draft plans, undo/redo, optimistic locking.
+- **Draw.io export.** One page per tray, EIA-598 colors, diff annotations.
+- **Custom cable profiles.** 24, 48, 72, 96, 144, 216, 288, and 432 strand
+  profiles plus trunk profiles, registered via a startup monkey-patch
+  (NetBox's built-in profiles cap at 16 positions).
+- **REST API and GraphQL.** Every model is exposed; the splice plan viewset
+  has dedicated `bulk-update`, `apply`, `import-from-device`, and `diff`
+  actions.
+- **Search integration.** `FiberCableType`, `FiberCable`, `SplicePlan`,
+  `SpliceProject`, `FiberCircuit`, `SlackLoop`, and `TrayProfile` are
+  registered with NetBox's global search.
+- **Sample data.** A `create_sample_data` management command builds a full
+  ISP-scale topology (380+ closures, 460+ plant cables, 5 fiber circuits) for
+  demo, screenshots, and benchmarking.
+
+## Quick install
+
+```bash
+pip install netbox-fms
+```
+
+```python
+# configuration.py
+PLUGINS = ["netbox_fms"]
+```
+
+```bash
+cd /opt/netbox/netbox
+python manage.py migrate
+sudo systemctl restart netbox netbox-rq
+```
+
+See [Installation](getting-started/installation.md) for the full procedure.
 
 ---
 
@@ -22,25 +87,27 @@ Fiber cable management, splice planning, and circuit provisioning for NetBox.
 
 -   **Getting Started**
 
-    Install and configure the plugin in your NetBox environment.
+    Install, configure, and walk through your first cable, splice plan, and
+    circuit.
 
     [:octicons-arrow-right-24: Getting Started](getting-started/installation.md)
 
 -   **User Guide**
 
-    Learn how to use each feature, from cable types to splice planning.
+    Cable types, cables, splice planning, fiber circuits, the splice editor,
+    closures, and slack loops.
 
     [:octicons-arrow-right-24: User Guide](user-guide/concepts.md)
 
 -   **Developer**
 
-    Architecture overview, REST API reference, and contributing guidelines.
+    Architecture, REST API, GraphQL, signals, services, and contributing.
 
     [:octicons-arrow-right-24: Developer](developer/architecture.md)
 
 -   **Reference**
 
-    Choice values, cable profiles, and configuration options.
+    Choice values, cable profiles, permissions, and management commands.
 
     [:octicons-arrow-right-24: Reference](reference/choices.md)
 

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -21,7 +21,7 @@ NetBox FMS applies the same idea to fiber cables:
 | NetBox core | DeviceType | Device |
 | NetBox FMS | **FiberCableType** | **FiberCable** |
 
-### FiberCableType — the Blueprint
+### FiberCableType -- the Blueprint
 
 A **FiberCableType** defines a cable's construction: how many tubes it has, how
 many fibers per tube, whether it uses ribbons, and what non-fiber elements
@@ -30,14 +30,14 @@ distinct cable product you use, then reuse it every time you install that cable.
 
 The blueprint is built from **component templates**:
 
-- **BufferTubeTemplate** — defines a buffer tube and its fiber count or ribbon
+- **BufferTubeTemplate** -- defines a buffer tube and its fiber count or ribbon
   children.
-- **RibbonTemplate** — defines a fiber ribbon (can be a child of a
+- **RibbonTemplate** -- defines a fiber ribbon (can be a child of a
   BufferTubeTemplate or attached directly to the FiberCableType).
-- **CableElementTemplate** — defines non-fiber elements such as strength
+- **CableElementTemplate** -- defines non-fiber elements such as strength
   members, ripcords, or armor.
 
-### FiberCable — the Instance
+### FiberCable -- the Instance
 
 A **FiberCable** represents a specific physical cable installed in your network.
 Each FiberCable is linked one-to-one with a NetBox `dcim.Cable` record, giving
@@ -46,11 +46,11 @@ it endpoints, length, and path information.
 When a FiberCable is created, the plugin reads the associated FiberCableType and
 **automatically instantiates** all internal components:
 
-- **BufferTube** — a physical tube inside the cable.
-- **Ribbon** — a fiber ribbon grouping multiple strands.
-- **FiberStrand** — an individual optical fiber, automatically colored using the
+- **BufferTube** -- a physical tube inside the cable.
+- **Ribbon** -- a fiber ribbon grouping multiple strands.
+- **FiberStrand** -- an individual optical fiber, automatically colored using the
   EIA-598 standard.
-- **CableElement** — a non-fiber component (strength member, armor, etc.).
+- **CableElement** -- a non-fiber component (strength member, armor, etc.).
 
 No manual creation of strands or tubes is required. The type defines the
 structure; the instance builds it.
@@ -152,7 +152,7 @@ FiberStrands attached directly to the FiberCable.
 ## EIA-598 Color Code
 
 NetBox FMS automatically assigns colors to FiberStrands using the **TIA/EIA-598**
-standard color code. You do not need to set strand colors manually — they are
+standard color code. You do not need to set strand colors manually -- they are
 determined by the strand's position within its parent (tube, ribbon, or cable).
 
 The 12 standard fiber colors are:

--- a/docs/user-guide/device-fiber-overview.md
+++ b/docs/user-guide/device-fiber-overview.md
@@ -56,7 +56,7 @@ Closure devices with approved splice plans display a **Pending Work** tab on the
 Instead of applying plans individually, the Pending Work tab merges all approved plans into a single operation:
 
 1. Multiple teams create splice plans for the same closure (each plan is independent).
-2. Plans go through the approval workflow (draft → pending_approval → approved).
+2. Plans go through the approval workflow (draft -> pending_approval -> approved).
 3. A field technician opens the closure's Pending Work tab and reviews the combined diff.
 4. The "Apply All" action commits all changes in a single atomic transaction.
 5. Applied plans are automatically archived.

--- a/docs/user-guide/fiber-circuits.md
+++ b/docs/user-guide/fiber-circuits.md
@@ -1,90 +1,350 @@
 # Fiber Circuits
 
-## Overview
+A **FiberCircuit** is the end-to-end logical service that runs over your
+fiber plant. Where a `dcim.Cable` represents one physical span, a fiber
+circuit ties together all of the spans, splices, and ports that carry one
+service from origin to destination, with optional parallel paths for
+diversity. Circuits are first-class NetBox objects with their own status
+lifecycle, REST API, GraphQL type, change log, and search index.
 
-A FiberCircuit represents an end-to-end logical service over fiber infrastructure, tracking the physical path from origin to destination. Fiber circuits tie together cables, port mappings, splice entries, and fiber strands into a single traceable entity with status lifecycle management and loss budget tracking.
+The circuit subsystem has three responsibilities:
 
-## Data Model
+1. **Discovery.** Given two devices, find candidate paths through the fiber
+   graph (cables + closures + existing splices), score them, and return
+   ranked proposals.
+2. **Provisioning.** Materialize a chosen proposal as a `FiberCircuit` plus
+   one `FiberCircuitPath` per strand, atomically.
+3. **Protection.** Once a circuit is active, prevent its underlying
+   resources (cables, ports, strands, splice entries) from being deleted or
+   re-spliced out from under it.
+
+---
+
+## Data model
+
+```mermaid
+erDiagram
+    FiberCircuit ||--o{ FiberCircuitPath : has
+    FiberCircuitPath ||--o{ FiberCircuitNode : has
+    FiberCircuitPath }o--|| FrontPort : "origin (dcim)"
+    FiberCircuitPath }o--o| FrontPort : "destination (dcim)"
+    FiberCircuitNode }o--o| Cable : "cable (dcim)"
+    FiberCircuitNode }o--o| FrontPort : "front_port (dcim)"
+    FiberCircuitNode }o--o| RearPort : "rear_port (dcim)"
+    FiberCircuitNode }o--o| FiberStrand : "fiber_strand"
+    FiberCircuitNode }o--o| SplicePlanEntry : "splice_entry"
+```
 
 ### FiberCircuit
 
-The top-level circuit object. Each FiberCircuit has a name, description, and a status that governs its lifecycle. It serves as the logical container for one or more paths that describe how light travels from origin to destination.
+The top-level service object.
+
+| Field           | Type                          | Notes                                                                |
+| --------------- | ----------------------------- | -------------------------------------------------------------------- |
+| `name`          | char(200)                     | Display name, required                                               |
+| `cid`           | char(200)                     | External circuit identifier (work order, internal CID, etc.)         |
+| `status`        | choice                        | `planned`, `staged`, `active`, `decommissioned`                      |
+| `description`   | text                          | Free-form description                                                |
+| `strand_count`  | positive int                  | Number of parallel strand paths the circuit reserves                 |
+| `tenant`        | FK -> `tenancy.Tenant`        | Optional tenant attribution                                          |
+| `comments`      | text                          | Long-form notes                                                      |
+
+A circuit's `strand_count` caps how many `FiberCircuitPath` rows can hang
+off it. Saving the circuit with `status=decommissioned` deletes all
+`FiberCircuitNode` rows so the underlying objects are no longer protected.
+Moving a decommissioned circuit back to any other status rebuilds nodes by
+calling `FiberCircuitPath.rebuild_nodes()` from the stored path JSON.
 
 ### FiberCircuitPath
 
-An ordered sequence of nodes representing a route from origin to destination. Each path carries a `position` field for ordering, a `calculated_loss_db` field for computed optical loss, an `actual_loss_db` field for measured loss, and a `wavelength_nm` field for the operating wavelength.
+One strand's journey from origin to destination.
+
+| Field                | Type                | Notes                                                |
+| -------------------- | ------------------- | ---------------------------------------------------- |
+| `circuit`            | FK -> `FiberCircuit` | Owning circuit                                       |
+| `position`           | positive int        | 1-indexed ordering within the circuit                |
+| `origin`             | FK -> `dcim.FrontPort` | Path entry point                                  |
+| `destination`        | FK -> `dcim.FrontPort` | Path exit point (nullable for incomplete traces)  |
+| `path`               | JSON list           | Ordered hop records (front_port / rear_port / cable / splice_entry) |
+| `is_complete`        | bool                | `True` if the trace reached a destination            |
+| `calculated_loss_db` | decimal(6,3)        | Optional design-time loss budget                     |
+| `actual_loss_db`     | decimal(6,3)        | Optional measured loss (OTDR, power meter)           |
+| `wavelength_nm`      | positive int        | Wavelength the loss values apply to; required if either loss is set |
+
+`(circuit, position)` is unique. `clean()` enforces the strand-count cap and
+that `wavelength_nm` is set whenever `calculated_loss_db` or `actual_loss_db`
+is populated.
 
 ### FiberCircuitNode
 
-An individual hop within a path. Each node references the physical infrastructure at that point in the route:
+A relational index of every object on a path. Each node references one of
+`cable`, `front_port`, `rear_port`, `fiber_strand`, or `splice_entry` via
+`on_delete=PROTECT`. This is what enforces circuit protection: as long as
+the circuit is not decommissioned, deleting any of those underlying objects
+raises `ProtectedError`.
 
-| Field          | Description                                      |
-|----------------|--------------------------------------------------|
-| `cable`        | The `dcim.Cable` traversed at this hop           |
-| `front_port`   | The `dcim.FrontPort` at entry or exit            |
-| `rear_port`    | The `dcim.RearPort` at entry or exit             |
-| `fiber_strand` | The `FiberStrand` carried through this segment   |
-| `splice_entry` | The `SplicePlanEntry` joining two fibers         |
+Nodes are not edited directly. They are rebuilt automatically on path
+retrace, on circuit status transitions, and during provisioning.
 
-## Status Lifecycle
+---
 
-Fiber circuits follow a four-stage lifecycle:
+## Status lifecycle
 
-| Status           | Description                                                        |
-|------------------|--------------------------------------------------------------------|
-| Planned          | Circuit has been designed but not yet staged for deployment.       |
-| Staged           | Circuit is approved and ready for provisioning on the network.     |
-| Active           | Circuit is live and carrying traffic.                              |
-| Decommissioned   | Circuit has been taken out of service.                             |
+| Status            | Meaning                                                                           |
+| ----------------- | --------------------------------------------------------------------------------- |
+| `planned`         | Circuit has been designed but not yet staged. Nodes exist; resources are protected. |
+| `staged`          | Circuit is ready for cutover; pre-deployment activities are in progress.          |
+| `active`          | Circuit is live and carrying traffic.                                             |
+| `decommissioned`  | Circuit is no longer in service. Nodes are deleted; resources are no longer protected. |
 
-## Path Trace Flow
+There is no enforced state-machine: any transition is permitted, and the
+side effects on `FiberCircuitNode` rows (delete on entering
+`decommissioned`, rebuild on leaving) happen automatically in `save()`.
 
-The path tracing algorithm navigates the physical infrastructure graph by following port mappings and cable connections:
+---
 
-```mermaid
-flowchart LR
-    FP1[FrontPort] --> PM1[PortMapping]
-    PM1 --> RP1[RearPort]
-    RP1 --> CABLE[Cable]
-    CABLE --> RP2[RearPort]
-    RP2 --> PM2[PortMapping]
-    PM2 --> FP2[FrontPort]
-    FP2 -.-> |"splice"| FP3[FrontPort]
-    FP3 --> PM3[PortMapping]
-    PM3 --> |"repeat..."| NEXT[...]
+## Discovery: `find_fiber_paths()`
+
+The discovery engine lives in `netbox_fms.provisioning`. The public entry
+point is:
+
+```python
+from netbox_fms.provisioning import find_fiber_paths
+
+proposals = find_fiber_paths(
+    origin_device,
+    destination_device,
+    strand_count=1,
+    priorities=None,            # default: ["hop_count", "new_splices",
+                                #           "strand_adjacency", "lowest_strand"]
+    max_results=20,
+)
 ```
 
-At each device, the trace follows the internal port mapping from FrontPort to RearPort, then crosses a cable to reach the RearPort on the next device, and maps back to a FrontPort. When a splice entry connects two FrontPorts, the trace crosses the splice and continues the pattern on the next segment.
+### Algorithm
 
-## Circuit Provisioning Workflow
+1. **Build a device graph.** All cables that terminate on `RearPort`
+   instances are collected. Each cable becomes a bidirectional edge between
+   the two devices its rear ports belong to.
+2. **Enumerate simple routes.** Depth-first search finds every simple path
+   (no repeated devices) between origin and destination, up to a default
+   max depth of 10.
+3. **Compute hop availability.** For each hop along each route, look at the
+   PortMappings on both ends and find the `RearPort` positions that have
+   matching FrontPorts on entry and exit, with neither FrontPort already
+   occupied (terminated by a non-zero-length cable).
+4. **Generate candidates.** For single-hop routes, every group of
+   `strand_count` available positions on the same cable is a candidate.
+   For multi-hop routes, the engine builds chains: each chain enters a
+   closure on one cable and exits on the next, with a splice (existing or
+   to-be-created) at the intermediate device.
+5. **Score and rank.** Each candidate is scored by the priority list in
+   order. Lower is better.
 
-Provisioning a fiber circuit follows a four-step process:
+### Scoring priorities
 
-1. **Select origin and destination devices.** Identify the endpoints that the circuit must connect.
+| Priority           | Meaning                                                          |
+| ------------------ | ---------------------------------------------------------------- |
+| `hop_count`        | Fewer cable spans win                                            |
+| `new_splices`      | Reuse existing splices over creating new ones                    |
+| `strand_adjacency` | Prefer strands that are contiguous within a cable                |
+| `lowest_strand`    | Prefer lower-numbered strand positions (deterministic ordering)  |
 
-2. **Discover candidate paths.** The `find_fiber_paths()` function performs a breadth-first search over the fiber infrastructure DAG, starting from the origin device and exploring all reachable routes toward the destination.
+Pass a different ordering or subset to change the ranking. For example, if
+you care more about reusing splices than minimizing hops:
 
-3. **Evaluate proposals.** The search returns ranked proposals that include available strand information for each segment. This allows the operator to choose a path based on strand availability, hop count, or expected loss.
+```python
+proposals = find_fiber_paths(
+    origin, dest, strand_count=2,
+    priorities=["new_splices", "hop_count", "strand_adjacency"],
+)
+```
 
-4. **Create the circuit atomically.** Calling `create_circuit_from_proposal()` atomically creates the FiberCircuit, its FiberCircuitPath, and all FiberCircuitNode records in a single transaction. This ensures the circuit is either fully provisioned or not created at all.
+### Proposal shape
 
-## Path Tracing
+Each proposal is a dict:
 
-The `trace_fiber_path()` function walks the physical graph starting from a given FrontPort:
+```python
+{
+    "strands": [
+        {
+            "hops": [
+                {
+                    "cable_id": 42,
+                    "fp_entry_id": 101,
+                    "fp_exit_id": 105,
+                    "entry_rp_id": 71,
+                    "exit_rp_id": 72,
+                    "position": 7,
+                },
+                # ...
+            ],
+            "position": 7,
+        },
+        # one entry per requested strand
+    ],
+    "route": [12, 34, 56],   # ordered device IDs
+    "hop_count": 2,
+    "new_splice_count": 1,
+    "existing_splice_count": 0,
+    "is_contiguous": True,
+    "lowest_position": 7,
+    "splices_needed": [
+        {"device_id": 34, "fp_a_id": 105, "fp_b_id": 110},
+    ],
+}
+```
 
-1. Follow the internal port mapping from FrontPort to its paired RearPort.
-2. Cross the cable connected to that RearPort, arriving at the RearPort on the remote device.
-3. Follow the port mapping on the remote device from RearPort back to a FrontPort.
-4. If a SplicePlanEntry connects this FrontPort to another FrontPort, cross the splice and repeat from step 1.
-5. If no further connection exists, the trace terminates.
+---
 
-The algorithm maintains a set of visited nodes and terminates immediately if a loop is detected, preventing infinite traversal in misconfigured topologies.
+## Provisioning: `create_circuit_from_proposal()`
 
-## Loss Budgets
+Once a proposal is selected, materialize it atomically:
 
-Each FiberCircuitPath carries two loss fields:
+```python
+from netbox_fms.provisioning import create_circuit_from_proposal
 
-- **`calculated_loss_db`** — the computed optical loss for the route, based on fiber attenuation, splice losses, and connector losses along the path.
-- **`actual_loss_db`** — the measured loss from OTDR or power meter testing in the field.
+circuit = create_circuit_from_proposal(
+    proposals[0],
+    name="DC1-DC2 backbone A",          # or use name_template
+    name_template="Circuit-{n}",        # auto-incrementing fallback
+    splice_project=my_project,          # optional SpliceProject for new splices
+)
+```
 
-Comparing calculated and actual loss values helps identify anomalies such as bad splices or damaged fiber. Circuits whose loss exceeds the receiver sensitivity threshold for the deployed transceiver modules can be flagged for review before activation.
+Inside a single transaction, the helper:
+
+1. Creates the `FiberCircuit` with `status=planned` and `strand_count`
+   matching the number of strands in the proposal.
+2. Creates one `FiberCircuitPath` per strand, populating `origin`,
+   `destination`, `path` (the hop JSON), and `is_complete=True`.
+3. Creates `FiberCircuitNode` rows for every front port, rear port, cable,
+   and splice entry on the path, plus one node per `FiberStrand` derived
+   from the path's front ports.
+4. For each `splices_needed` entry, creates a zero-length `dcim.Cable` with
+   `FrontPort` <-> `FrontPort` terminations (a splice cable) and a matching
+   `SplicePlanEntry`. If `splice_project` is provided, a draft plan is
+   created or reused for that closure under that project; otherwise the
+   first existing plan on the closure is used.
+
+If the transaction fails for any reason, no circuit, paths, nodes, splice
+cables, or plan entries are created.
+
+The classmethod helpers `FiberCircuit.find_paths()` and
+`FiberCircuit.create_from_proposal()` proxy to the provisioning module if
+you prefer the model-side API.
+
+---
+
+## Tracing and retracing
+
+The trace engine lives in `netbox_fms.trace`. From a starting `FrontPort`
+it walks the chain `FrontPort -> PortMapping -> RearPort ->
+CableTermination -> Cable -> remote RearPort -> PortMapping -> FrontPort`,
+crossing splices (`SplicePlanEntry`) when one is present. Loops are
+detected and stop the trace.
+
+`FiberCircuitPath.from_origin(front_port)` returns an unsaved path with
+the trace populated. `FiberCircuitPath.retrace()` re-runs the trace from
+`self.origin`, updates `path` / `destination` / `is_complete`, saves, and
+either rebuilds protection nodes (active circuit) or deletes them
+(decommissioned circuit).
+
+The REST API exposes both:
+
+```bash
+# Per-path hop-by-hop trace with computed totals
+GET /api/plugins/fms/fiber-circuit-paths/{id}/trace/
+
+# Retrace every path on a circuit
+POST /api/plugins/fms/fiber-circuits/{id}/retrace/
+```
+
+The trace endpoint returns `{circuit_id, circuit_name, path_position,
+is_complete, hops, total_calculated_loss_db, total_actual_loss_db,
+wavelength_nm}` along with hop records suitable for rendering in the UI's
+trace view.
+
+---
+
+## Loss budgets
+
+Each path tracks two loss values:
+
+- **`calculated_loss_db`**: design-time estimate based on fiber attenuation
+  per kilometer, splice losses, and connector losses.
+- **`actual_loss_db`**: measured value from OTDR or power meter testing.
+
+Both fields are decimal(6,3). When either is set, `wavelength_nm` is
+required so the loss is interpretable. Compare planned versus measured
+loss to spot bad splices or damaged fiber, or to validate that the circuit
+is within receiver sensitivity for the deployed transceivers.
+
+The plugin does not currently compute losses automatically: enter the
+calculated value manually based on your loss budget tooling, then update
+`actual_loss_db` after field testing.
+
+---
+
+## Circuit protection
+
+Circuit protection is what stops you from breaking a live service while
+modifying NetBox. Every object on a non-decommissioned circuit's path has a
+matching `FiberCircuitNode` with `on_delete=PROTECT`, so:
+
+- Deleting a `dcim.Cable` referenced by an active path raises
+  `ProtectedError`.
+- Deleting a `FrontPort` or `RearPort` carrying an active circuit raises
+  `ProtectedError`.
+- Bulk-updating splice plan entries that touch a protected fiber returns
+  HTTP 409 with a body listing the conflicting circuit names. See
+  `/api/plugins/fms/splice-plans/{id}/bulk-update/` and the closure
+  Pending Work tab for the user-facing surface.
+
+The dedicated endpoint `GET /api/plugins/fms/fiber-circuits/protecting/`
+takes one or more of `cable=`, `front_port=`, `rear_port=`,
+`fiber_strand=`, or `splice_entry=` (comma-separated IDs) and returns the
+circuits whose paths reference any of them. Use it to surface "which
+circuits would be affected" in dashboards or pre-flight checks.
+
+To take resources out from under protection, set the circuit to
+`decommissioned`. The `save()` override deletes its `FiberCircuitNode`
+rows in the same transaction.
+
+---
+
+## Common workflows
+
+### Provision a new dark-fiber circuit between two POPs
+
+```python
+from dcim.models import Device
+from netbox_fms.provisioning import find_fiber_paths, create_circuit_from_proposal
+
+origin = Device.objects.get(name="POP-A-CLOSURE")
+dest   = Device.objects.get(name="POP-B-CLOSURE")
+
+proposals = find_fiber_paths(origin, dest, strand_count=2,
+                             priorities=["hop_count", "new_splices"])
+best = proposals[0]
+circuit = create_circuit_from_proposal(best, name="POP-A <-> POP-B (Pair 1)")
+```
+
+### Cut a circuit over to a new path
+
+1. Create the new circuit with `create_circuit_from_proposal()`. It enters
+   `planned` status, so its nodes are protected immediately.
+2. Verify the new path with `POST .../{id}/retrace/`.
+3. Decommission the old circuit (set status to `decommissioned`). Its
+   protection nodes are deleted, freeing the previously held splices.
+4. Set the new circuit to `active`.
+
+### Inventory all circuits affected by a planned outage
+
+```bash
+curl -s -H "Authorization: Token $TOKEN" \
+  "$NETBOX_URL/api/plugins/fms/fiber-circuits/protecting/?cable=42,43,44"
+```
+
+The response is a standard fiber-circuit list, suitable for a customer
+notification spreadsheet or a maintenance ticket.

--- a/docs/user-guide/splice-planning.md
+++ b/docs/user-guide/splice-planning.md
@@ -122,9 +122,9 @@ To resolve a conflict, either archive the competing plan or remove the conflicti
 
 The `approve_spliceplan` permission controls who can act as an approver. Users with this permission can:
 
-- Approve a plan (pending_approval → approved)
-- Reject a plan (pending_approval → draft)
-- Reopen an approved plan (approved → draft)
+- Approve a plan (pending_approval -> approved)
+- Reject a plan (pending_approval -> draft)
+- Reopen an approved plan (approved -> draft)
 
 Assign this permission to leads, network engineers, or anyone responsible for validating splice designs before they are applied to the network.
 


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.