### PR TITLE
chore: log plugin name on load

### DIFF
--- a/netbox_fms/__init__.py
+++ b/netbox_fms/__init__.py
@@ -1,6 +1,10 @@
+import logging
+
 from netbox.plugins import PluginConfig
 
 __version__ = "0.1.0"
+
+logger = logging.getLogger(__name__)
 
 
 class NetBoxFMSConfig(PluginConfig):
@@ -29,6 +33,7 @@ class NetBoxFMSConfig(PluginConfig):
         connect_counters(FiberCableType)
 
         self._register_map_layers()
+        logger.info("%s plugin loaded", self.name)
 
     @staticmethod
     def _register_map_layers():


### PR DESCRIPTION
## Summary

- Logs the plugin name once during `ready()` so the NetBox process log confirms which plugin loaded after a restart.

## Changes

- `netbox_fms/__init__.py`: emit a single info log line on plugin load.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Plugin still loads without errors after restart

## Context

This commit was sitting unpushed on local `main` ahead of beginning ESRI cross-walk feature work (issues #22 / #23 / #24). Branched out of main into its own PR so the feature branches start from a clean origin/main.