### PR TITLE
chore(renovate): group updates and auto-merge non-major bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "github-actions (non-major)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "groupName": "dev npm dependencies (non-major)"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "platformAutomerge": true
+    }
   ]
 }
-


### PR DESCRIPTION
## Summary
- Group GitHub Actions and dev npm devDependencies into rolling non-major PRs to cut PR volume.
- Auto-merge non-major bumps (minor / patch / pin / digest) once CI is green.
- Major bumps continue to land as individual PRs for explicit review.

## Changes
- renovate.json: extend `config:recommended` with three packageRules covering grouping and auto-merge.

## Testing
- [ ] Renovate's next run reflects the new grouping in the dependency dashboard
- [ ] Open non-major PRs auto-merge once their CI is green
- [ ] Major bumps remain individual PRs

## Notes
- `platformAutomerge: true` uses GitHub's native auto-merge. Requires "Allow auto-merge" enabled under Settings > General > Pull Requests; otherwise Renovate falls back to its own merge logic.
- Mirrors the canonical baseline being rolled out across all user-owned plugins.
