### PR TITLE
feat: add splice closure creation wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Splice closure creation wizard: **FMS > Add Splice Closure** creates the
+  closure Device with named "Tray 1..N" module bays, tray modules, and
+  optional express basket bays in one atomic action. Requires tray
+  ModuleTypes marked with a TrayProfile.
+
 ### Changed
 
 - Docs: documented the full splice-closure preparation workflow (closure device, tray module types with TrayProfiles, module bays/modules, ClosureCableEntry before TubeAssignment, tray-module FrontPorts) in the quickstart and splice-planning guide; added TrayProfile and TubeAssignment to the splice-planning core objects and a Tray Assignments section to the device fiber overview guide. Removed patch-panel framing -- the plugin's workflows are closure-centric and patch panels are not modeled at this time. Fixed the quickstart incorrectly stating that a SpliceProject is associated with a closure (the SplicePlan targets the closure; the project is an optional grouping).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,40 +28,62 @@ A FiberCableType is the blueprint that describes how a cable is constructed.
 5. Choose the construction style. For a loose tube cable, add **BufferTubeTemplates** -- for example, 4 tubes with 12 fibers each.
 6. Save the cable type.
 
-## 3. Create a Splice Closure Device
+## 3. One-Time Catalog Setup for Closures
 
-A splice closure is a regular NetBox device. If you do not already have one:
+Before creating closure devices, the catalog needs one entry per hardware
+model (this is done once, then reused for every closure):
 
 1. Navigate to **Devices > Device Types** and create a device type for the
    closure model (e.g., "FOSC 450"), with a matching device role (e.g.,
    "Splice Closure").
-2. Navigate to **Devices > Devices** and create the closure device at its site
-   (e.g., "Closure-A"). Repeat for the far end of the cable (another closure
-   or any fiber-terminating device).
-
-You do not need to pre-define front ports on the closure -- the plugin creates
-the per-strand ports when you link the cable topology (step 6).
-
-## 4. Model the Closure's Splice Trays
-
-Splice trays are NetBox **Modules** installed in the closure, and the plugin
-needs to know which module types are trays:
-
-1. Navigate to **Devices > Module Types** and create a module type for each
+2. Navigate to **Devices > Module Types** and create a module type for each
    tray product (e.g., "24F Splice Tray").
-2. Navigate to **FMS > Tray Profiles** and click **Add**. Select the module
+3. Navigate to **FMS > Tray Profiles** and click **Add**. Select the module
    type, set the **tray role** to **Splice Tray**, and set **max fibers** to
    the tray's splice capacity. Use the **Express Basket** role for
    pass-through storage baskets -- tubes can only be assigned to splice trays.
-3. On the closure device, create **Module Bays** (e.g., "Bay 1", "Bay 2") and
-   install a **Module** of the tray module type in each bay.
+
+You do not need to define front ports anywhere -- the plugin creates the
+per-strand ports when you link the cable topology (step 6).
+
+## 4. Create the Splice Closure
+
+Navigate to **FMS > Add Splice Closure**. The wizard creates the device and
+its trays in one atomic action:
+
+1. Enter the device name (e.g., "Closure-A"), site, device type, and role.
+2. Pick the splice tray type and how many trays the closure holds; the
+   wizard creates a "Tray 1..N" module bay with an installed tray module for
+   each.
+3. Optionally pick an express basket type and count ("Basket 1..N").
+4. Save. Repeat for the far end of the cable (another closure or any
+   fiber-terminating device).
+
+The closure can also be assembled manually (device, module bays, modules) --
+the wizard is a convenience, not a requirement.
 
 ## 5. Create a Cable
 
-1. Navigate to **Devices** and select one of the closure devices.
-2. Create a `dcim.Cable` between the two devices with a fiber cable type
-   (e.g., **SMF OS2**).
-3. Save the cable.
+Create a `dcim.Cable` between the two devices with a fiber cable type (e.g.,
+**SMF OS2**). Where to terminate it depends on what the closure already has:
+
+- **The closure has rear ports** (defined on its device type or created
+  manually): open the closure device, find the rear port, click **Connect**,
+  and terminate the cable there. The plugin's topology linking will detect the
+  existing ports and offer to adopt them.
+- **The closure is bare** (no ports yet, the usual case for a new closure):
+  the cable must be created without closure-side terminations, which NetBox
+  validation does not allow through the web UI, the REST API, or bulk import
+  (a new cable requires both end terminations). Until a guided flow exists,
+  create it from a NetBox shell:
+
+  ```python
+  from dcim.models import Cable
+  cable = Cable.objects.create(type="smf-os2", label="Closure-A <-> Closure-B")
+  ```
+
+  The plugin creates the per-tube rear ports and terminates the cable onto
+  them in the next step -- you do not connect anything by hand.
 
 ## 6. Create a Fiber Cable
 
@@ -79,11 +101,17 @@ On save, the plugin automatically instantiates the internal cable structure base
 
 Navigate to the new FiberCable's detail page to inspect the generated tubes and strands.
 
-Alternatively, use the **Link Topology** action on the closure's **Fiber
-Overview** tab. It performs the same FiberCable creation and additionally
-provisions the per-strand FrontPorts, per-tube RearPorts, and PortMappings on
-the closure, and sets the cable profile used by NetBox's trace engine. See
-[Fiber Cables](../user-guide/fiber-cables.md#linking-cable-topology).
+The FiberCable itself carries no ports. To create the per-strand FrontPorts,
+per-tube RearPorts, and PortMappings on the closure, use one of:
+
+- **Link Topology** on the closure's **Fiber Overview** tab -- available for
+  cables that already terminate at the closure. It creates the FiberCable and
+  the ports in one operation, terminates the cable onto the new rear ports,
+  and sets the cable profile used by NetBox's trace engine. See
+  [Fiber Cables](../user-guide/fiber-cables.md#linking-cable-topology).
+- **Provision Ports** on the FiberCable's detail page -- pick the closure
+  device and port type, and the plugin creates the ports for every strand.
+  Use this when the cable was created without closure-side terminations.
 
 ## 7. Register the Cable at the Closure
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,19 +71,23 @@ Create a `dcim.Cable` between the two devices with a fiber cable type (e.g.,
   manually): open the closure device, find the rear port, click **Connect**,
   and terminate the cable there. The plugin's topology linking will detect the
   existing ports and offer to adopt them.
-- **The closure is bare** (no ports yet, the usual case for a new closure):
-  the cable must be created without closure-side terminations, which NetBox
-  validation does not allow through the web UI, the REST API, or bulk import
-  (a new cable requires both end terminations). Until a guided flow exists,
-  create it from a NetBox shell:
+- **The closure is bare** (no ports yet): creating a cable without
+  closure-side terminations is **not supported**. NetBox validation requires
+  both end terminations on a new cable, and the web UI, REST API, and bulk
+  import all enforce it. Prefer the supported path above: give the closure
+  rear ports first, then connect the cable to them.
+
+  Advanced users can bypass this validation from a NetBox shell, at their
+  own risk (the ORM skips model validation entirely):
 
   ```python
   from dcim.models import Cable
   cable = Cable.objects.create(type="smf-os2", label="Closure-A <-> Closure-B")
   ```
 
-  The plugin creates the per-tube rear ports and terminates the cable onto
-  them in the next step -- you do not connect anything by hand.
+  If you do this, the plugin creates the per-tube rear ports and terminates
+  the cable onto them in the next step -- you do not connect anything by
+  hand.
 
 ## 6. Create a Fiber Cable
 

--- a/docs/user-guide/splice-planning.md
+++ b/docs/user-guide/splice-planning.md
@@ -74,11 +74,10 @@ Deleting a ClosureCableEntry automatically removes that cable's TubeAssignments 
 
 Before a closure device can host splice plans, it needs its physical structure modeled. This mirrors the setup performed once per closure in the field:
 
-1. **Create the closure device.** A splice closure is a regular `dcim.Device` with an appropriate device type and role (e.g., "Splice Closure").
-2. **Model the trays.** Create a `dcim.ModuleType` per tray product and mark it with a **TrayProfile** (role and capacity). Add module bays to the closure and install a module per physical tray.
-3. **Terminate cables and provision ports.** Link each incoming cable's topology (see [Fiber Cables](fiber-cables.md#linking-cable-topology)) so every strand has a FrontPort on the closure. Splice plan entries require each fiber's FrontPort to belong to a tray module.
-4. **Register cable entrances.** Create a **ClosureCableEntry** per cable, recording its gland or entrance label.
-5. **Assign tubes to trays.** Create **TubeAssignments** manually or use the auto-assign action on the closure's Fiber Overview tab, which pairs same-position tubes from different cables onto the same tray while capacity allows.
+1. **Create the closure device and its trays** in one step via **FMS > Add Splice Closure**: pick the device type and role, a splice tray module type and count, and optionally an express basket. The wizard creates the device with "Tray 1..N" (and "Basket 1..N") module bays and installed modules atomically. Prerequisite (once per hardware model): a `dcim.DeviceType` for the closure and tray `dcim.ModuleType`s marked with a **TrayProfile** (role and capacity). The closure can also be assembled manually from those same primitives.
+2. **Terminate cables and provision ports.** Link each incoming cable's topology (see [Fiber Cables](fiber-cables.md#linking-cable-topology)) so every strand has a FrontPort on the closure. Splice plan entries require each fiber's FrontPort to belong to a tray module.
+3. **Register cable entrances.** Create a **ClosureCableEntry** per cable, recording its gland or entrance label.
+4. **Assign tubes to trays.** Create **TubeAssignments** manually or use the auto-assign action on the closure's Fiber Overview tab, which pairs same-position tubes from different cables onto the same tray while capacity allows.
 
 Once this structure exists, plans can be authored, reviewed, and applied against the closure.
 

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -1,7 +1,9 @@
-from dcim.choices import CableLengthUnitChoices, PortTypeChoices
+from dcim.choices import CableLengthUnitChoices, DeviceStatusChoices, PortTypeChoices
 from dcim.models import (
     Cable,
     Device,
+    DeviceRole,
+    DeviceType,
     FrontPort,
     Location,
     Manufacturer,
@@ -1170,3 +1172,39 @@ class TubeAssignmentFilterForm(NetBoxModelFilterSetForm):
     closure_id = DynamicModelChoiceField(queryset=Device.objects.all(), required=False, label=_("Closure"))
 
     fieldsets = (FieldSet("q", "closure_id", "tag", name=_("Filters")),)
+
+
+class SpliceClosureCreateForm(forms.Form):
+    """Guided creation of a splice closure: device + tray/basket modules.
+
+    Tray/basket type fields are plain ModelChoiceFields (not Dynamic): the
+    dcim REST API cannot filter ModuleTypes by the plugin's TrayProfile role.
+    """
+
+    name = forms.CharField(label=_("Name"), max_length=64)
+    site = DynamicModelChoiceField(queryset=Site.objects.all(), label=_("Site"))
+    location = DynamicModelChoiceField(
+        queryset=Location.objects.all(),
+        label=_("Location"),
+        required=False,
+        query_params={"site_id": "$site"},
+    )
+    device_type = DynamicModelChoiceField(queryset=DeviceType.objects.all(), label=_("Device type"))
+    role = DynamicModelChoiceField(queryset=DeviceRole.objects.all(), label=_("Role"))
+    status = forms.ChoiceField(
+        choices=DeviceStatusChoices,
+        initial=DeviceStatusChoices.STATUS_ACTIVE,
+        label=_("Status"),
+    )
+    tray_module_type = forms.ModelChoiceField(
+        queryset=ModuleType.objects.filter(tray_profile__tray_role=TrayRoleChoices.SPLICE_TRAY),
+        label=_("Splice tray type"),
+        help_text=_("Module types marked as splice trays via a Tray Profile."),
+    )
+    tray_count = forms.IntegerField(min_value=1, initial=1, label=_("Tray count"))
+    basket_module_type = forms.ModelChoiceField(
+        queryset=ModuleType.objects.filter(tray_profile__tray_role=TrayRoleChoices.EXPRESS_BASKET),
+        label=_("Express basket type"),
+        required=False,
+    )
+    basket_count = forms.IntegerField(min_value=1, initial=1, required=False, label=_("Basket count"))

--- a/netbox_fms/navigation.py
+++ b/netbox_fms/navigation.py
@@ -166,6 +166,19 @@ menu = PluginMenu(
             "Splice Planning",
             (
                 PluginMenuItem(
+                    link="plugins:netbox_fms:spliceclosure_add",
+                    link_text="Add Splice Closure",
+                    permissions=["dcim.add_device"],
+                    buttons=(
+                        PluginMenuButton(
+                            link="plugins:netbox_fms:spliceclosure_add",
+                            title="Add Splice Closure",
+                            icon_class="mdi mdi-auto-fix",
+                            permissions=["dcim.add_device"],
+                        ),
+                    ),
+                ),
+                PluginMenuItem(
                     link="plugins:netbox_fms:spliceproject_list",
                     link_text="Splice Projects",
                     permissions=["netbox_fms.view_spliceproject"],

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -1,6 +1,6 @@
 """Diff computation engine for splice plans and link topology services."""
 
-from dcim.models import Cable, CableTermination, FrontPort, PortMapping, RearPort
+from dcim.models import Cable, CableTermination, Device, FrontPort, Module, ModuleBay, PortMapping, RearPort
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
@@ -430,3 +430,49 @@ def apply_diff(plan):
         plan.save(update_fields=["diff_stale"])
 
     return {"added": added, "removed": removed}
+
+
+@transaction.atomic
+def create_splice_closure(
+    *,
+    name,
+    site,
+    device_type,
+    role,
+    status,
+    tray_module_type,
+    tray_count,
+    basket_module_type=None,
+    basket_count=0,
+    location=None,
+):
+    """Create a splice closure Device with tray (and optional basket) modules.
+
+    All objects are full_clean()ed; any failure rolls back the entire closure.
+    Returns the created Device.
+    """
+    device = Device(
+        name=name,
+        site=site,
+        location=location,
+        device_type=device_type,
+        role=role,
+        status=status,
+    )
+    device.full_clean()
+    device.save()
+
+    def _add_modules(prefix, module_type, count):
+        for i in range(1, count + 1):
+            bay = ModuleBay(device=device, name=f"{prefix} {i}")
+            bay.full_clean()
+            bay.save()
+            module = Module(device=device, module_bay=bay, module_type=module_type)
+            module.full_clean()
+            module.save()
+
+    _add_modules("Tray", tray_module_type, tray_count)
+    if basket_module_type is not None:
+        _add_modules("Basket", basket_module_type, basket_count)
+
+    return device

--- a/netbox_fms/templates/netbox_fms/spliceclosure_add.html
+++ b/netbox_fms/templates/netbox_fms/spliceclosure_add.html
@@ -1,0 +1,33 @@
+{% extends 'base/layout.html' %}
+{% load form_helpers %}
+{% load i18n %}
+
+{% block title %}{% trans "Add Splice Closure" %}{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col col-md-8">
+        <div class="card">
+            <h5 class="card-header"><i class="mdi mdi-auto-fix"></i> {% trans "Add Splice Closure" %}</h5>
+            <div class="card-body">
+                {% if not form.fields.tray_module_type.queryset.exists %}
+                <div class="alert alert-warning">
+                    {% blocktrans %}No splice tray module types are defined yet. Create a
+                    Tray Profile for your tray module types first.{% endblocktrans %}
+                    <a href="{% url 'plugins:netbox_fms:trayprofile_add' %}">{% trans "Add Tray Profile" %}</a>
+                </div>
+                {% endif %}
+                <form method="post">
+                    {% csrf_token %}
+                    {% render_form form %}
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="mdi mdi-auto-fix"></i> {% trans "Create Closure" %}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_fms/urls.py
+++ b/netbox_fms/urls.py
@@ -191,6 +191,8 @@ urlpatterns = [
     ),
     path("splice-plans/<int:pk>/apply/", views.SplicePlanApplyView.as_view(), name="spliceplan_apply"),
     path("splice-plans/<int:pk>/export/", views.SplicePlanExportDrawioView.as_view(), name="spliceplan_export"),
+    # Splice Closure wizard
+    path("splice-closures/add/", views.SpliceClosureCreateView.as_view(), name="spliceclosure_add"),
     # TrayProfile
     path("tray-profiles/", views.TrayProfileListView.as_view(), name="trayprofile_list"),
     path("tray-profiles/add/", views.TrayProfileEditView.as_view(), name="trayprofile_add"),

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -77,6 +77,7 @@ from .forms import (
     SlackLoopFilterForm,
     SlackLoopForm,
     SlackLoopImportForm,
+    SpliceClosureCreateForm,
     SplicePlanBulkEditForm,
     SplicePlanEntryFilterForm,
     SplicePlanEntryForm,
@@ -120,6 +121,7 @@ from .provisioning import create_circuit_from_proposal, find_fiber_paths
 from .services import (
     NeedsMappingConfirmation,
     apply_diff,
+    create_splice_closure,
     get_or_recompute_diff,
     import_live_state,
     link_cable_topology,
@@ -2703,3 +2705,54 @@ class AutoAssignTubesView(LoginRequiredMixin, View):
                 request, "netbox_fms/htmx/tray_assignments_card.html", {"device": device, "tray_data": tray_data}
             )
         return redirect(reverse("dcim:device", kwargs={"pk": pk}) + "fiber-overview/")
+
+
+# ---------------------------------------------------------------------------
+# Splice Closure wizard
+# ---------------------------------------------------------------------------
+
+
+class SpliceClosureCreateView(LoginRequiredMixin, View):
+    """Guided creation of a splice closure device with tray modules."""
+
+    required_perms = ("dcim.add_device", "dcim.add_modulebay", "dcim.add_module")
+    template_name = "netbox_fms/spliceclosure_add.html"
+
+    def _check_perms(self, request):
+        return request.user.has_perms(self.required_perms)
+
+    def get(self, request):
+        """Render the closure creation form."""
+        if not self._check_perms(request):
+            return HttpResponse("Permission denied", status=403)
+        form = SpliceClosureCreateForm()
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request):
+        """Create the closure and redirect to its Fiber Overview tab."""
+        if not self._check_perms(request):
+            return HttpResponse("Permission denied", status=403)
+        form = SpliceClosureCreateForm(request.POST)
+        if form.is_valid():
+            try:
+                device = create_splice_closure(
+                    name=form.cleaned_data["name"],
+                    site=form.cleaned_data["site"],
+                    location=form.cleaned_data["location"],
+                    device_type=form.cleaned_data["device_type"],
+                    role=form.cleaned_data["role"],
+                    status=form.cleaned_data["status"],
+                    tray_module_type=form.cleaned_data["tray_module_type"],
+                    tray_count=form.cleaned_data["tray_count"],
+                    basket_module_type=form.cleaned_data["basket_module_type"],
+                    basket_count=form.cleaned_data["basket_count"] or 0,
+                )
+            except ValidationError as e:
+                for field, errors in getattr(e, "error_dict", {"__all__": e.error_list}).items():
+                    target = field if field in form.fields else None
+                    for error in errors:
+                        form.add_error(target, error)
+            else:
+                messages.success(request, _('Created splice closure "{name}".').format(name=device.name))
+                return redirect(reverse("dcim:device", kwargs={"pk": device.pk}) + "fiber-overview/")
+        return render(request, self.template_name, {"form": form})

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -2748,7 +2748,8 @@ class SpliceClosureCreateView(LoginRequiredMixin, View):
                     basket_count=form.cleaned_data["basket_count"] or 0,
                 )
             except ValidationError as e:
-                for field, errors in getattr(e, "error_dict", {"__all__": e.error_list}).items():
+                error_map = getattr(e, "error_dict", None) or {"__all__": list(e)}
+                for field, errors in error_map.items():
                     target = field if field in form.fields else None
                     for error in errors:
                         form.add_error(target, error)

--- a/tests/test_splice_closure_wizard.py
+++ b/tests/test_splice_closure_wizard.py
@@ -1,0 +1,159 @@
+"""Tests for the splice closure creation wizard (service, form, view)."""
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.urls import reverse
+
+from netbox_fms.choices import TrayRoleChoices
+from netbox_fms.forms import SpliceClosureCreateForm
+from netbox_fms.models import TrayProfile
+from netbox_fms.services import create_splice_closure
+
+
+class TestCreateSpliceClosure(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.create(name="Wizard Site", slug="wizard-site")
+        mfr = Manufacturer.objects.create(name="Wizard Mfr", slug="wizard-mfr")
+        cls.device_type = DeviceType.objects.create(manufacturer=mfr, model="FOSC 450", slug="fosc-450")
+        cls.role = DeviceRole.objects.create(name="Splice Closure", slug="splice-closure")
+        cls.tray_mt = ModuleType.objects.create(manufacturer=mfr, model="24F Tray")
+        TrayProfile.objects.create(module_type=cls.tray_mt, tray_role=TrayRoleChoices.SPLICE_TRAY)
+        cls.basket_mt = ModuleType.objects.create(manufacturer=mfr, model="Express Basket")
+        TrayProfile.objects.create(module_type=cls.basket_mt, tray_role=TrayRoleChoices.EXPRESS_BASKET)
+
+    def test_creates_device_with_named_tray_bays_and_modules(self):
+        device = create_splice_closure(
+            name="Closure-W1",
+            site=self.site,
+            device_type=self.device_type,
+            role=self.role,
+            status="active",
+            tray_module_type=self.tray_mt,
+            tray_count=3,
+        )
+        bays = ModuleBay.objects.filter(device=device).order_by("name")
+        assert [b.name for b in bays] == ["Tray 1", "Tray 2", "Tray 3"]
+        modules = Module.objects.filter(device=device)
+        assert modules.count() == 3
+        assert all(m.module_type == self.tray_mt for m in modules)
+
+    def test_creates_optional_basket_bays(self):
+        device = create_splice_closure(
+            name="Closure-W2",
+            site=self.site,
+            device_type=self.device_type,
+            role=self.role,
+            status="active",
+            tray_module_type=self.tray_mt,
+            tray_count=2,
+            basket_module_type=self.basket_mt,
+            basket_count=1,
+        )
+        names = set(ModuleBay.objects.filter(device=device).values_list("name", flat=True))
+        assert names == {"Tray 1", "Tray 2", "Basket 1"}
+        assert Module.objects.filter(device=device, module_type=self.basket_mt).count() == 1
+
+    def test_no_basket_bays_without_basket_type(self):
+        device = create_splice_closure(
+            name="Closure-W3",
+            site=self.site,
+            device_type=self.device_type,
+            role=self.role,
+            status="active",
+            tray_module_type=self.tray_mt,
+            tray_count=1,
+            basket_count=2,  # ignored without basket_module_type
+        )
+        assert not ModuleBay.objects.filter(device=device, name__startswith="Basket").exists()
+
+    def test_validation_failure_creates_nothing(self):
+        create_splice_closure(
+            name="Closure-DUP",
+            site=self.site,
+            device_type=self.device_type,
+            role=self.role,
+            status="active",
+            tray_module_type=self.tray_mt,
+            tray_count=1,
+        )
+        with self.assertRaises(ValidationError):
+            create_splice_closure(
+                name="Closure-DUP",  # duplicate name at same site
+                site=self.site,
+                device_type=self.device_type,
+                role=self.role,
+                status="active",
+                tray_module_type=self.tray_mt,
+                tray_count=5,
+            )
+        # exactly the first closure's objects exist; the failed call left nothing
+        assert Device.objects.filter(name="Closure-DUP").count() == 1
+        assert ModuleBay.objects.filter(device__name="Closure-DUP").count() == 1
+
+
+class TestSpliceClosureCreateForm(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        mfr = Manufacturer.objects.create(name="Form Mfr", slug="form-mfr")
+        cls.tray_mt = ModuleType.objects.create(manufacturer=mfr, model="Form 24F Tray")
+        TrayProfile.objects.create(module_type=cls.tray_mt, tray_role=TrayRoleChoices.SPLICE_TRAY)
+        cls.basket_mt = ModuleType.objects.create(manufacturer=mfr, model="Form Basket")
+        TrayProfile.objects.create(module_type=cls.basket_mt, tray_role=TrayRoleChoices.EXPRESS_BASKET)
+        cls.plain_mt = ModuleType.objects.create(manufacturer=mfr, model="Form Plain Module")
+
+    def test_tray_queryset_only_offers_splice_tray_profiles(self):
+        form = SpliceClosureCreateForm()
+        qs = form.fields["tray_module_type"].queryset
+        assert self.tray_mt in qs
+        assert self.basket_mt not in qs
+        assert self.plain_mt not in qs
+
+    def test_basket_queryset_only_offers_express_basket_profiles(self):
+        form = SpliceClosureCreateForm()
+        qs = form.fields["basket_module_type"].queryset
+        assert self.basket_mt in qs
+        assert self.tray_mt not in qs
+        assert self.plain_mt not in qs
+
+
+class TestSpliceClosureCreateView(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.create(name="View Site", slug="view-site")
+        mfr = Manufacturer.objects.create(name="View Mfr", slug="view-mfr")
+        cls.device_type = DeviceType.objects.create(manufacturer=mfr, model="View FOSC", slug="view-fosc")
+        cls.role = DeviceRole.objects.create(name="View Closure", slug="view-closure")
+        cls.tray_mt = ModuleType.objects.create(manufacturer=mfr, model="View 24F Tray")
+        TrayProfile.objects.create(module_type=cls.tray_mt, tray_role=TrayRoleChoices.SPLICE_TRAY)
+        cls.url = reverse("plugins:netbox_fms:spliceclosure_add")
+
+    def test_permission_gate_returns_403_without_dcim_perms(self):
+        User = get_user_model()
+        user = User.objects.create_user("wizard-nobody", "n@test.com", "password")
+        self.client.force_login(user)
+        assert self.client.get(self.url).status_code == 403
+
+    def test_post_creates_closure_and_redirects_to_fiber_overview(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser("wizard-admin", "a@test.com", "password")
+        self.client.force_login(admin)
+        response = self.client.post(
+            self.url,
+            {
+                "name": "Closure-V1",
+                "site": self.site.pk,
+                "device_type": self.device_type.pk,
+                "role": self.role.pk,
+                "status": "active",
+                "tray_module_type": self.tray_mt.pk,
+                "tray_count": 2,
+                "basket_count": 1,
+            },
+        )
+        device = Device.objects.get(name="Closure-V1")
+        assert ModuleBay.objects.filter(device=device).count() == 2
+        assert response.status_code == 302
+        assert response.url.endswith(f"/dcim/devices/{device.pk}/fiber-overview/")

--- a/tests/test_splice_closure_wizard.py
+++ b/tests/test_splice_closure_wizard.py
@@ -135,6 +135,42 @@ class TestSpliceClosureCreateView(TestCase):
         user = User.objects.create_user("wizard-nobody", "n@test.com", "password")
         self.client.force_login(user)
         assert self.client.get(self.url).status_code == 403
+        assert self.client.post(self.url, {}).status_code == 403
+
+    def test_get_renders_form_for_permitted_user(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser("wizard-getter", "g@test.com", "password")
+        self.client.force_login(admin)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert isinstance(response.context["form"], SpliceClosureCreateForm)
+
+    def test_post_duplicate_name_maps_validation_error_to_field(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser("wizard-dup", "d@test.com", "password")
+        self.client.force_login(admin)
+        Device.objects.create(name="Closure-V2", site=self.site, device_type=self.device_type, role=self.role)
+        response = self.client.post(
+            self.url,
+            {
+                "name": "Closure-V2",  # collides with the existing device
+                "site": self.site.pk,
+                "device_type": self.device_type.pk,
+                "role": self.role.pk,
+                "status": "active",
+                "tray_module_type": self.tray_mt.pk,
+                "tray_count": 1,
+            },
+        )
+        # ValidationError from Device.full_clean() is mapped onto the form;
+        # Device raises uniqueness as a non-field ('__all__') error
+        assert response.status_code == 200
+        form = response.context["form"]
+        assert form.non_field_errors()
+        assert "unique" in str(form.non_field_errors())
+        # the failed attempt created nothing
+        assert Device.objects.filter(name="Closure-V2").count() == 1
+        assert not ModuleBay.objects.filter(device__name="Closure-V2").exists()
 
     def test_post_creates_closure_and_redirects_to_fiber_overview(self):
         User = get_user_model()


### PR DESCRIPTION
## Summary
- Adds a guided UI flow (FMS > Add Splice Closure) that instantiates a splice closure in one atomic action: the Device, named "Tray 1..N" module bays with installed tray modules, and optional "Basket 1..N" express basket bays.
- Fixes the workflow gap where a closure could only be assembled by hand across five separate pages (DeviceType, DeviceRole, Device, ModuleBays + Modules, TrayProfiles).
- Corrects quickstart guidance on cable creation: NetBox validation requires both end terminations on new cables through every user-facing channel, so the previously documented import/API paths do not work.

## Changes
- netbox_fms/services.py: create_splice_closure() atomic service (device + tray/basket bays and modules, all full_clean()ed)
- netbox_fms/forms.py: SpliceClosureCreateForm; tray/basket type querysets filtered by TrayProfile role (plain ModelChoiceFields -- the dcim REST API cannot filter ModuleTypes by plugin TrayProfile role)
- netbox_fms/views.py: SpliceClosureCreateView gated on dcim.add_device/add_modulebay/add_module; redirects to the new device's Fiber Overview tab
- netbox_fms/urls.py: splice-closures/add/ route
- netbox_fms/navigation.py: Add Splice Closure menu entry (mdi-auto-fix icon)
- netbox_fms/templates/netbox_fms/spliceclosure_add.html: form page with empty-catalog callout linking to Tray Profiles
- tests/test_splice_closure_wizard.py: service structure/rollback, form queryset filtering, permission gate, POST round-trip
- docs + CHANGELOG: quickstart wizard-first rewrite, splice-planning Preparing a Closure update

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (455 passed, full plugin suite)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (n/a -- no schema change)
- [x] Docs updated (README n/a, CHANGELOG, zensical pages)

## Screenshots / output
n/a (server-rendered form; no JS)

## Related
Refs: splice closure workflow discussion (cable-from-closure flow to follow in a separate PR)