### PR TITLE
fix(views): provision B side on second provisioning run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docs: documented the full splice-closure preparation workflow (closure device, tray module types with TrayProfiles, module bays/modules, ClosureCableEntry before TubeAssignment, tray-module FrontPorts) in the quickstart and splice-planning guide; added TrayProfile and TubeAssignment to the splice-planning core objects and a Tray Assignments section to the device fiber overview guide. Removed patch-panel framing -- the plugin's workflows are closure-centric and patch panels are not modeled at this time. Fixed the quickstart incorrectly stating that a SpliceProject is associated with a closure (the SplicePlan targets the closure; the project is an optional grouping).
 
+### Fixed
+
+- Provision Ports: a second provisioning run against another device now
+  provisions the B side instead of silently overwriting the A side; a
+  further run when both sides are provisioned fails with a clear error
+  instead of clobbering existing assignments. (#70)
+
 ## [0.2.0] - 2026-05-26
 
 ### Added

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -1833,6 +1833,15 @@ def provision_strands(fiber_cable, device, port_type, module=None):
     if strand_count == 0:
         raise ValueError("This fiber cable has no strands.")
 
+    # Provision the A side first; once any strand has an A-side port, the next
+    # provisioning run targets the B side (issue #70).
+    if not strands.filter(front_port_a__isnull=False).exists():
+        side_field = "front_port_a"
+    elif not strands.filter(front_port_b__isnull=False).exists():
+        side_field = "front_port_b"
+    else:
+        raise ValueError("Both sides of this fiber cable are already provisioned.")
+
     cable_label = str(fiber_cable.cable) if fiber_cable.cable else f"FiberCable-{fiber_cable.pk}"
 
     # PortMapping only has device, front_port, rear_port — no module field.
@@ -1869,8 +1878,8 @@ def provision_strands(fiber_cable, device, port_type, module=None):
                 rear_port_position=strand.position,
             )
 
-            strand.front_port_a = fp
-            strand.save(update_fields=["front_port_a"])
+            setattr(strand, side_field, fp)
+            strand.save(update_fields=[side_field])
 
 
 class ProvisionPortsView(LoginRequiredMixin, View):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -281,3 +281,40 @@ class TestProvisionStrandsHelper(TestCase):
 
         fps = FrontPort.objects.filter(device=self.device, module__isnull=True)
         assert fps.count() == 4
+
+    def _create_second_device(self):
+        site = Site.objects.get(slug="prov-test-site")
+        device_type = DeviceType.objects.get(slug="prov-closure")
+        role = DeviceRole.objects.get(slug="prov-role")
+        return Device.objects.create(name="Prov-Device-B", site=site, device_type=device_type, role=role)
+
+    def test_second_provision_populates_b_side(self):
+        """Regression for issue #70: provisioning a second device must fill
+        front_port_b instead of overwriting front_port_a."""
+        device_b = self._create_second_device()
+
+        cable = Cable.objects.create()
+        fiber_cable = FiberCable.objects.create(cable=cable, fiber_cable_type=self.fct)
+        provision_strands(fiber_cable, self.device, port_type="splice")
+        provision_strands(fiber_cable, device_b, port_type="splice")
+
+        for strand in fiber_cable.fiber_strands.all():
+            assert strand.front_port_a is not None
+            assert strand.front_port_a.device == self.device
+            assert strand.front_port_b is not None
+            assert strand.front_port_b.device == device_b
+
+    def test_provision_fails_when_both_sides_provisioned(self):
+        device_b = self._create_second_device()
+        site = Site.objects.get(slug="prov-test-site")
+        device_type = DeviceType.objects.get(slug="prov-closure")
+        role = DeviceRole.objects.get(slug="prov-role")
+        device_c = Device.objects.create(name="Prov-Device-C", site=site, device_type=device_type, role=role)
+
+        cable = Cable.objects.create()
+        fiber_cable = FiberCable.objects.create(cable=cable, fiber_cable_type=self.fct)
+        provision_strands(fiber_cable, self.device, port_type="splice")
+        provision_strands(fiber_cable, device_b, port_type="splice")
+
+        with self.assertRaises(ValueError):
+            provision_strands(fiber_cable, device_c, port_type="splice")


### PR DESCRIPTION
## Summary
- Provision Ports always wrote the A side; a second run against another device silently overwrote every strand's front_port_a instead of provisioning the B side
- The side is now selected once per run (A when unset, otherwise B), and a run with both sides provisioned fails with a clear form error

## Changes
- netbox_fms/views.py: provision_strands() picks the target side field per run and raises ValueError when both sides are provisioned
- tests/test_models.py: regression tests for B-side provisioning on second run and error on third run
- CHANGELOG.md: Fixed entry under Unreleased

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (459 passed)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Fixes #70