### PR TITLE
feat(templates): link FiberCable instance from Cable detail card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The "Fiber Cable" card on NetBox's Cable detail page now links to the FMS
+  FiberCable instance, so Cable -> FiberCable navigation is one click away
+  (the reverse link already existed). (#57)
 - Import forms now declare choice fields as `CSVChoiceField` (`construction`
   and `color_scheme` on FiberCableType, `storage_method` on SlackLoop) so the
   bulk-import UI documents the valid values for each column.

--- a/netbox_fms/templates/netbox_fms/inc/cable_fibercable_panel.html
+++ b/netbox_fms/templates/netbox_fms/inc/cable_fibercable_panel.html
@@ -5,6 +5,10 @@
     <h2 class="card-header">{% trans "Fiber Cable" %}</h2>
     <table class="table table-hover attr-table">
         <tr>
+            <th scope="row">{% trans "Fiber Cable" %}</th>
+            <td><a href="{{ fiber_cable.get_absolute_url }}">{{ fiber_cable }}</a></td>
+        </tr>
+        <tr>
             <th scope="row">{% trans "Fiber Cable Type" %}</th>
             <td><a href="{{ fiber_cable.fiber_cable_type.get_absolute_url }}">{{ fiber_cable.fiber_cable_type }}</a></td>
         </tr>


### PR DESCRIPTION
## Summary
- The "Fiber Cable" card that FMS injects into NetBox's Cable detail page showed FiberCableType details but no way to reach the FMS FiberCable instance itself; FiberCable -> Cable navigation existed while the reverse did not.
- Adds a "Fiber Cable" row as the first row of the card, linking to the FiberCable detail view.

## Changes
- netbox_fms/templates/netbox_fms/inc/cable_fibercable_panel.html: new first row linking to the FiberCable instance
- CHANGELOG.md: entry under [Unreleased] > Changed

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] Template-only change; no plugin logic added, so no new tests per the repo's test-scope policy
- [ ] pytest (CI matrix)
- [x] No migration
- [x] CHANGELOG updated; README/docs unaffected (minor UI affordance)

## Screenshots / output
The card gains a first row "Fiber Cable" -> "<cable> (<cable type>)" linking to the FMS instance; no screenshot captured in this environment.

## Related
Fixes #57