### PR TITLE
feat(filters): chain Tube Assignment buffer tube dropdown on closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parent type's standard (position-ordered, with an "Other" fallback
   group). Fixes #60.
 
+- `closure_id` filter on BufferTube (REST API and UI): tubes of fiber
+  cables entering a given closure, via ClosureCableEntry. The Tube
+  Assignment form's Buffer Tube dropdown now chains on the selected
+  Closure so only tubes of cables entering that closure are offered. (#58)
+
 ### Changed
 
 - Import forms now declare choice fields as `CSVChoiceField` (`construction`

--- a/netbox_fms/filters.py
+++ b/netbox_fms/filters.py
@@ -209,12 +209,18 @@ class BufferTubeFilterSet(SearchFieldsMixin, NetBoxModelFilterSet):
         field_name="fiber_cable",
         label=_("Fiber Cable (ID)"),
     )
+    closure_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Device.objects.all(),
+        field_name="fiber_cable__closure_entries__closure",
+        label=_("Closure (ID)"),
+        distinct=True,
+    )
 
     search_fields = ("name__icontains",)
 
     class Meta:
         model = BufferTube
-        fields = ("id", "fiber_cable_id", "name", "position")
+        fields = ("id", "fiber_cable_id", "closure_id", "name", "position")
 
 
 class RibbonFilterSet(SearchFieldsMixin, NetBoxModelFilterSet):

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -1165,7 +1165,11 @@ class TubeAssignmentForm(NetBoxModelForm):
     tray = DynamicModelChoiceField(
         queryset=Module.objects.all(), label=_("Tray"), query_params={"device_id": "$closure"}
     )
-    buffer_tube = DynamicModelChoiceField(queryset=BufferTube.objects.all(), label=_("Buffer Tube"))
+    buffer_tube = DynamicModelChoiceField(
+        queryset=BufferTube.objects.all(),
+        label=_("Buffer Tube"),
+        query_params={"closure_id": "$closure"},
+    )
 
     fieldsets = (FieldSet("closure", "tray", "buffer_tube", "position", "notes", "tags", name=_("Tube Assignment")),)
 

--- a/tests/test_tray_assignment.py
+++ b/tests/test_tray_assignment.py
@@ -310,3 +310,50 @@ class TestTubeAssignmentAPI(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.json()["count"] == 1
+
+
+class TestBufferTubeClosureFilter(TestCase):
+    """BufferTubeFilterSet.closure_id narrows tubes to cables entering a closure (#58)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from dcim.models import Cable
+
+        site = Site.objects.create(name="BTF Site", slug="btf-site")
+        mfr = Manufacturer.objects.create(name="BTF Mfr", slug="btf-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="BTF Closure", slug="btf-closure")
+        role = DeviceRole.objects.create(name="BTF Role", slug="btf-role")
+        cls.closure_a = Device.objects.create(name="BTF-A", site=site, device_type=dt, role=role)
+        cls.closure_b = Device.objects.create(name="BTF-B", site=site, device_type=dt, role=role)
+
+        fct = FiberCableType.objects.create(
+            manufacturer=mfr,
+            model="BTF-12F",
+            construction="loose_tube",
+            strand_count=12,
+        )
+        cable_a = FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
+        cable_b = FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
+        cls.tube_a = BufferTube.objects.create(fiber_cable=cable_a, name="BTF-T-A", position=1)
+        cls.tube_b = BufferTube.objects.create(fiber_cable=cable_b, name="BTF-T-B", position=1)
+
+        ClosureCableEntry.objects.create(closure=cls.closure_a, fiber_cable=cable_a, entrance_label="Gland A")
+        ClosureCableEntry.objects.create(closure=cls.closure_b, fiber_cable=cable_b, entrance_label="Gland B")
+
+    def test_closure_id_returns_only_entering_cables_tubes(self):
+        from netbox_fms.filters import BufferTubeFilterSet
+
+        qs = BufferTubeFilterSet({"closure_id": [self.closure_a.pk]}, queryset=BufferTube.objects.all()).qs
+        assert set(qs) == {self.tube_a}
+
+    def test_unfiltered_returns_all_tubes(self):
+        from netbox_fms.filters import BufferTubeFilterSet
+
+        qs = BufferTubeFilterSet({}, queryset=BufferTube.objects.all()).qs
+        assert {self.tube_a, self.tube_b} <= set(qs)
+
+    def test_form_buffer_tube_field_chains_on_closure(self):
+        from netbox_fms.forms import TubeAssignmentForm
+
+        field = TubeAssignmentForm().fields["buffer_tube"]
+        assert field.query_params == {"closure_id": "$closure"}


### PR DESCRIPTION
## Summary
- The Tube Assignment form's Buffer Tube dropdown listed every tube in the database; it now only offers tubes of fiber cables that enter the closure selected in the Closure dropdown.
- Implemented as a new `closure_id` filter on BufferTubeFilterSet traversing `fiber_cable__closure_entries__closure` (ClosureCableEntry is the closure/cable join), chained on the form via `query_params={"closure_id": "$closure"}` -- the same pattern the Tray dropdown already uses. The filter is also usable directly on the REST API list endpoint.

## Changes
- netbox_fms/filters.py: `closure_id` ModelMultipleChoiceFilter on BufferTubeFilterSet (distinct, added to Meta.fields)
- netbox_fms/forms.py: TubeAssignmentForm.buffer_tube gains `query_params={"closure_id": "$closure"}`
- tests/test_tray_assignment.py: filterset narrowing, unfiltered passthrough, and form chaining pinned (TDD red-first)
- CHANGELOG.md: entry under [Unreleased] > Added

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (test_tray_assignment.py: 21 passed)
- [x] New behavior covered by tests
- [x] No migration
- [x] CHANGELOG updated

## Screenshots / output
Selecting a Closure now narrows the Buffer Tube dropdown to tubes of cables entering that closure; no screenshot captured in this environment.

## Related
Fixes #58