### PR TITLE
feat: sync strand front ports to tray modules on tube assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Buffer tube and ribbon template color pickers now group choices by the
   parent type's standard (position-ordered, with an "Other" fallback
   group). Fixes #60.
+- Tube assignments now manage dcim port placement: assigning a buffer tube
+  to a splice tray moves the tube's closure-side strand FrontPorts onto the
+  tray module, re-pointing follows tray/tube changes, and deleting the
+  assignment returns the ports to device level. Ports already owned by a
+  different module block the save with a list of conflicts until the new
+  `confirm_reassign` flag (form checkbox / REST field) is set. This is what
+  makes applied splices visible to the splice-state reader, which only
+  considers FrontPorts on tray modules. Pre-existing assignments are not
+  back-filled; re-save an assignment to sync its ports. (#68)
 
 ### Changed
 

--- a/docs/user-guide/device-fiber-overview.md
+++ b/docs/user-guide/device-fiber-overview.md
@@ -50,6 +50,10 @@ For closures with splice trays (modules whose type carries a [TrayProfile](splic
 
 Tubes can only be assigned once their fiber cable has a ClosureCableEntry on the closure. See [Splice Planning: Preparing a Closure](splice-planning.md#preparing-a-closure) for the full setup sequence.
 
+Assigning a tube to a tray moves the tube's closure-side strand front
+ports onto the tray module; removing the assignment returns them to the
+device. Note that the Assign and Auto-assign actions on this card move conflicting ports without prompting; the confirmation gate applies to the standard Tube Assignment form and the REST API.
+
 ## Splice Editor Widget
 
 An embedded splice editor is available directly from the device view, enabling quick creation and editing of splice plan entries without navigating away. This is particularly useful when:

--- a/docs/user-guide/splice-planning.md
+++ b/docs/user-guide/splice-planning.md
@@ -68,6 +68,17 @@ A TubeAssignment routes one BufferTube to one splice tray (a `dcim.Module`) insi
 
 Deleting a ClosureCableEntry automatically removes that cable's TubeAssignments on the closure.
 
+Assigning a tube to a tray also places the tube's strand front ports on
+the tray module in NetBox (only the ports on the assignment's closure;
+the far end is untouched). Changing the tray or tube moves the ports
+accordingly, and deleting the assignment returns them to the device. If a
+port already belongs to another module, the form lists the conflicts and
+requires the "Confirm reassignment" checkbox (REST: `confirm_reassign`)
+before overwriting. Splice state is read from front ports on tray
+modules, so this placement is what makes applied splices visible.
+
+Assignments created before this feature are not back-filled automatically: re-save an assignment (or change its tray) to sync its ports. Delete the tube assignment before deleting a tray module -- FrontPorts belong to the module once placed, so deleting the module deletes them.
+
 ---
 
 ## Preparing a Closure

--- a/netbox_fms/api/serializers.py
+++ b/netbox_fms/api/serializers.py
@@ -483,6 +483,12 @@ class TubeAssignmentSerializer(NetBoxModelSerializer):
     closure = DeviceSerializer(nested=True)
     tray = ModuleSerializer(nested=True)
     buffer_tube = BufferTubeSerializer(nested=True)
+    confirm_reassign = serializers.BooleanField(
+        write_only=True,
+        required=False,
+        default=False,
+        help_text="Move front ports that already belong to another module onto the selected tray.",
+    )
 
     class Meta:
         model = TubeAssignment
@@ -495,12 +501,39 @@ class TubeAssignmentSerializer(NetBoxModelSerializer):
             "buffer_tube",
             "position",
             "notes",
+            "confirm_reassign",
             "tags",
             "custom_fields",
             "created",
             "last_updated",
         )
         brief_fields = ("id", "url", "display", "closure", "tray", "buffer_tube")
+
+    def validate(self, data):
+        confirm = data.pop("confirm_reassign", False)
+        data = super().validate(data)
+        if confirm:
+            return data
+        instance = self.instance
+        candidate = TubeAssignment(
+            pk=instance.pk if instance else None,
+            closure=data.get("closure") or (instance.closure if instance else None),
+            tray=data.get("tray") or (instance.tray if instance else None),
+            buffer_tube=data.get("buffer_tube") or (instance.buffer_tube if instance else None),
+        )
+        if candidate.closure_id and candidate.tray_id and candidate.buffer_tube_id:
+            conflicts = candidate.conflicting_front_ports()
+            if conflicts:
+                names = ", ".join(sorted(port.name for port in conflicts))
+                raise serializers.ValidationError(
+                    {
+                        "confirm_reassign": (
+                            f"The following front ports already belong to another module: {names}. "
+                            "Set confirm_reassign to move them."
+                        )
+                    }
+                )
+        return data
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -1158,6 +1158,30 @@ class TrayProfileFilterForm(NetBoxModelFilterSetForm):
 # ---------------------------------------------------------------------------
 
 
+def _check_tube_assignment_conflicts(form):
+    """Shared confirm_reassign gate for TubeAssignment forms."""
+    if form.cleaned_data.get("confirm_reassign"):
+        return
+    closure = form.cleaned_data.get("closure")
+    tray = form.cleaned_data.get("tray")
+    buffer_tube = form.cleaned_data.get("buffer_tube")
+    if not (closure and tray and buffer_tube):
+        return
+    candidate = TubeAssignment(pk=form.instance.pk, closure=closure, tray=tray, buffer_tube=buffer_tube)
+    conflicts = candidate.conflicting_front_ports()
+    if conflicts:
+        names = ", ".join(sorted(port.name for port in conflicts))
+        raise ValidationError(
+            {
+                "confirm_reassign": _(
+                    "The following front ports already belong to another module: %(names)s. "
+                    "Confirm reassignment to move them to %(tray)s."
+                )
+                % {"names": names, "tray": tray}
+            }
+        )
+
+
 class TubeAssignmentForm(NetBoxModelForm):
     """Form for creating/editing a TubeAssignment."""
 
@@ -1166,20 +1190,39 @@ class TubeAssignmentForm(NetBoxModelForm):
         queryset=Module.objects.all(), label=_("Tray"), query_params={"device_id": "$closure"}
     )
     buffer_tube = DynamicModelChoiceField(queryset=BufferTube.objects.all(), label=_("Buffer Tube"))
+    confirm_reassign = forms.BooleanField(
+        required=False,
+        label=_("Confirm reassignment"),
+        help_text=_("Move front ports that already belong to another module onto the selected tray."),
+    )
 
-    fieldsets = (FieldSet("closure", "tray", "buffer_tube", "position", "notes", "tags", name=_("Tube Assignment")),)
+    fieldsets = (
+        FieldSet(
+            "closure", "tray", "buffer_tube", "position", "confirm_reassign", "notes", "tags", name=_("Tube Assignment")
+        ),
+    )
 
     class Meta:
         model = TubeAssignment
         fields = ("closure", "tray", "buffer_tube", "position", "notes", "tags")
+
+    def clean(self):
+        super().clean()
+        _check_tube_assignment_conflicts(self)
 
 
 class TubeAssignmentImportForm(NetBoxModelImportForm):
     """Import form for TubeAssignment."""
 
+    confirm_reassign = forms.BooleanField(required=False)
+
     class Meta:
         model = TubeAssignment
         fields = ("closure", "tray", "buffer_tube", "position", "notes", "tags")
+
+    def clean(self):
+        super().clean()
+        _check_tube_assignment_conflicts(self)
 
 
 class TubeAssignmentBulkEditForm(NetBoxModelBulkEditForm):

--- a/netbox_fms/models.py
+++ b/netbox_fms/models.py
@@ -1563,6 +1563,24 @@ class TubeAssignment(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:netbox_fms:tubeassignment", args=[self.pk])
 
+    def conflicting_front_ports(self):
+        """Target ports already owned by a module other than this assignment's tray.
+
+        "Allowed" modules are: none (device level), the target tray, and --
+        on updates -- the tray currently stored in the DB for this
+        assignment. Anything else is a conflict the user must confirm.
+        """
+        from .services import _tube_assignment_target_ports
+
+        allowed = {None, self.tray_id}
+        if self.pk:
+            allowed.add(TubeAssignment.objects.filter(pk=self.pk).values_list("tray_id", flat=True).first())
+        return [
+            port
+            for port in _tube_assignment_target_ports(self.closure_id, self.buffer_tube_id)
+            if port.module_id not in allowed
+        ]
+
     def clean(self):
         super().clean()
         from django.core.exceptions import ValidationError

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -543,3 +543,50 @@ def create_splice_closure(
         _add_modules("Basket", basket_module_type, basket_count)
 
     return device
+
+
+def _tube_assignment_target_ports(closure_id, buffer_tube_id):
+    """FrontPorts of the tube's strands that live on the closure device.
+
+    Each strand contributes at most one port (front_port_a or front_port_b,
+    whichever terminates on the closure); strands without a port there are
+    skipped.
+    """
+    from .models import FiberStrand
+
+    ports = []
+    strands = FiberStrand.objects.filter(buffer_tube_id=buffer_tube_id).select_related("front_port_a", "front_port_b")
+    for strand in strands:
+        for port in (strand.front_port_a, strand.front_port_b):
+            if port is not None and port.device_id == closure_id:
+                ports.append(port)
+                break
+    return ports
+
+
+def sync_tube_assignment_ports(assignment):
+    """Place the tube's closure-side strand front ports on the assignment's tray.
+
+    Overwrites unconditionally; conflict blocking happens at form/serializer
+    validation. Saves ports individually so NetBox change logging records
+    each move.
+    """
+    for port in _tube_assignment_target_ports(assignment.closure_id, assignment.buffer_tube_id):
+        if port.module_id != assignment.tray_id:
+            port.snapshot()
+            port.module_id = assignment.tray_id
+            port.save()
+
+
+def clear_tube_assignment_ports(closure_id, tray_id, buffer_tube_id):
+    """Return the tube's closure-side ports to device level.
+
+    Only touches ports still sitting on the given tray; ports moved
+    elsewhere by hand are left alone. Takes ids so it can run from a
+    post_delete signal.
+    """
+    for port in _tube_assignment_target_ports(closure_id, buffer_tube_id):
+        if port.module_id == tray_id:
+            port.snapshot()
+            port.module_id = None
+            port.save()

--- a/netbox_fms/signals.py
+++ b/netbox_fms/signals.py
@@ -198,6 +198,34 @@ def _closure_cable_entry_post_delete(sender, instance, **kwargs):
     ).delete()
 
 
+def _tube_assignment_pre_save(sender, instance, **kwargs):
+    """Release the previously synced ports when an assignment is re-pointed."""
+    if not instance.pk:
+        return
+    old = sender.objects.filter(pk=instance.pk).values("closure_id", "tray_id", "buffer_tube_id").first()
+    if old is None:
+        return
+    new = (instance.closure_id, instance.tray_id, instance.buffer_tube_id)
+    if (old["closure_id"], old["tray_id"], old["buffer_tube_id"]) != new:
+        from .services import clear_tube_assignment_ports
+
+        clear_tube_assignment_ports(old["closure_id"], old["tray_id"], old["buffer_tube_id"])
+
+
+def _tube_assignment_post_save(sender, instance, **kwargs):
+    """Place the tube's closure-side front ports on the assigned tray."""
+    from .services import sync_tube_assignment_ports
+
+    sync_tube_assignment_ports(instance)
+
+
+def _tube_assignment_post_delete(sender, instance, **kwargs):
+    """Return the tube's front ports to device level."""
+    from .services import clear_tube_assignment_ports
+
+    clear_tube_assignment_ports(instance.closure_id, instance.tray_id, instance.buffer_tube_id)
+
+
 def connect_signals():
     """Connect cable and device signals. Called from AppConfig.ready()."""
     from dcim.models import Cable
@@ -220,4 +248,12 @@ def connect_signals():
         _closure_cable_entry_post_delete,
         sender=ClosureCableEntry,
         dispatch_uid="fms_closure_cable_entry_post_delete",
+    )
+
+    from .models import TubeAssignment
+
+    pre_save.connect(_tube_assignment_pre_save, sender=TubeAssignment, dispatch_uid="fms_tube_assignment_pre_save")
+    post_save.connect(_tube_assignment_post_save, sender=TubeAssignment, dispatch_uid="fms_tube_assignment_post_save")
+    post_delete.connect(
+        _tube_assignment_post_delete, sender=TubeAssignment, dispatch_uid="fms_tube_assignment_post_delete"
     )

--- a/tests/test_tube_assignment_port_sync.py
+++ b/tests/test_tube_assignment_port_sync.py
@@ -115,3 +115,47 @@ class TestConflictDetection(PortSyncTestCase):
         port.save()
         ta = self._assignment(save=False)
         assert ta.conflicting_front_ports() == []
+
+
+class TestSignalWiring(PortSyncTestCase):
+    def test_create_moves_ports(self):
+        self._assignment()
+        self._refresh_ports()
+        assert all(p.module_id == self.tray1.pk for p in self.near_ports)
+
+    def test_tray_change_moves_ports(self):
+        ta = self._assignment()
+        ta.tray = self.tray2
+        ta.save()
+        self._refresh_ports()
+        assert all(p.module_id == self.tray2.pk for p in self.near_ports)
+
+    def test_buffer_tube_change_releases_old_tube_ports(self):
+        cable2 = FiberCable.objects.create(
+            cable=Cable.objects.create(), fiber_cable_type=self.fiber_cable.fiber_cable_type
+        )
+        tube2 = BufferTube.objects.create(fiber_cable=cable2, name="PS-T2", position=1)
+        other_port = make_front_port(device=self.closure, name="PS-N-T2")
+        strand2 = FiberStrand.objects.filter(fiber_cable=cable2, position=1).first()
+        strand2.buffer_tube = tube2
+        strand2.front_port_a = other_port
+        strand2.save()
+        ta = self._assignment()
+        ta.buffer_tube = tube2
+        ta.save()
+        self._refresh_ports()
+        other_port.refresh_from_db()
+        assert all(p.module_id is None for p in self.near_ports)
+        assert other_port.module_id == self.tray1.pk
+
+    def test_delete_returns_ports_to_device_level(self):
+        ta = self._assignment()
+        ta.delete()
+        self._refresh_ports()
+        assert all(p.module_id is None for p in self.near_ports)
+
+    def test_bulk_queryset_delete_returns_ports(self):
+        self._assignment()
+        TubeAssignment.objects.filter(closure=self.closure).delete()
+        self._refresh_ports()
+        assert all(p.module_id is None for p in self.near_ports)

--- a/tests/test_tube_assignment_port_sync.py
+++ b/tests/test_tube_assignment_port_sync.py
@@ -3,7 +3,18 @@
 from dcim.models import Cable, Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
 from django.test import TestCase
 
-from netbox_fms.models import BufferTube, ClosureCableEntry, FiberCable, FiberCableType, FiberStrand, TubeAssignment
+from netbox_fms.api.serializers import TubeAssignmentSerializer
+from netbox_fms.choices import TrayRoleChoices
+from netbox_fms.forms import TubeAssignmentForm, TubeAssignmentImportForm
+from netbox_fms.models import (
+    BufferTube,
+    ClosureCableEntry,
+    FiberCable,
+    FiberCableType,
+    FiberStrand,
+    TrayProfile,
+    TubeAssignment,
+)
 from netbox_fms.services import clear_tube_assignment_ports, sync_tube_assignment_ports
 from tests.conftest import make_front_port
 
@@ -21,6 +32,7 @@ class PortSyncTestCase(TestCase):
         cls.far_end = Device.objects.create(name="PS-FarEnd", site=site, device_type=dt, role=role)
 
         mt = ModuleType.objects.create(manufacturer=mfr, model="PS Tray")
+        TrayProfile.objects.create(module_type=mt, tray_role=TrayRoleChoices.SPLICE_TRAY)
         bay1 = ModuleBay.objects.create(device=cls.closure, name="Bay 1")
         bay2 = ModuleBay.objects.create(device=cls.closure, name="Bay 2")
         cls.tray1 = Module.objects.create(device=cls.closure, module_bay=bay1, module_type=mt)
@@ -159,3 +171,79 @@ class TestSignalWiring(PortSyncTestCase):
         TubeAssignment.objects.filter(closure=self.closure).delete()
         self._refresh_ports()
         assert all(p.module_id is None for p in self.near_ports)
+
+
+class TestConfirmReassign(PortSyncTestCase):
+    def _form_data(self, **overrides):
+        data = {
+            "closure": self.closure.pk,
+            "tray": self.tray1.pk,
+            "buffer_tube": self.tube.pk,
+        }
+        data.update(overrides)
+        return data
+
+    def test_form_blocks_conflict_without_flag(self):
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        form = TubeAssignmentForm(data=self._form_data())
+        assert not form.is_valid()
+        assert "PS-N1" in str(form.errors)
+
+    def test_form_allows_conflict_with_flag(self):
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        form = TubeAssignmentForm(data=self._form_data(confirm_reassign=True))
+        assert form.is_valid(), form.errors
+        form.save()
+        self._refresh_ports()
+        assert self.near_ports[0].module_id == self.tray1.pk
+
+    def test_form_clean_passes_without_conflicts(self):
+        form = TubeAssignmentForm(data=self._form_data())
+        assert form.is_valid(), form.errors
+
+    def test_serializer_blocks_conflict_without_flag(self):
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        ser = TubeAssignmentSerializer(
+            data={"closure": self.closure.pk, "tray": self.tray1.pk, "buffer_tube": self.tube.pk}
+        )
+        assert not ser.is_valid()
+        assert "PS-N1" in str(ser.errors)
+
+    def test_serializer_allows_conflict_with_flag(self):
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        ser = TubeAssignmentSerializer(
+            data={
+                "closure": self.closure.pk,
+                "tray": self.tray1.pk,
+                "buffer_tube": self.tube.pk,
+                "confirm_reassign": True,
+            }
+        )
+        assert ser.is_valid(), ser.errors
+        ser.save()
+        self._refresh_ports()
+        assert self.near_ports[0].module_id == self.tray1.pk
+
+    def test_serializer_partial_update_falls_back_to_instance(self):
+        ta = self._assignment()
+        self.near_ports[0].refresh_from_db()
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        ser = TubeAssignmentSerializer(instance=ta, data={"position": 5}, partial=True)
+        assert not ser.is_valid()
+        assert "PS-N1" in str(ser.errors)
+        ser = TubeAssignmentSerializer(instance=ta, data={"position": 5, "confirm_reassign": True}, partial=True)
+        assert ser.is_valid(), ser.errors
+
+    def test_import_form_blocks_conflict_without_flag(self):
+        self.near_ports[0].module = self.tray2
+        self.near_ports[0].save()
+        form = TubeAssignmentImportForm(
+            data={"closure": self.closure.pk, "tray": self.tray1.pk, "buffer_tube": self.tube.pk}
+        )
+        assert not form.is_valid()
+        assert "PS-N1" in str(form.errors)

--- a/tests/test_tube_assignment_port_sync.py
+++ b/tests/test_tube_assignment_port_sync.py
@@ -1,0 +1,117 @@
+"""Tests for tube-assignment driven FrontPort module sync (issue #68)."""
+
+from dcim.models import Cable, Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from django.test import TestCase
+
+from netbox_fms.models import BufferTube, ClosureCableEntry, FiberCable, FiberCableType, FiberStrand, TubeAssignment
+from netbox_fms.services import clear_tube_assignment_ports, sync_tube_assignment_ports
+from tests.conftest import make_front_port
+
+
+class PortSyncTestCase(TestCase):
+    """Closure with two trays, a far-end device, and a 2-strand tube with ports on both ends."""
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="PS Site", slug="ps-site")
+        mfr = Manufacturer.objects.create(name="PS Mfr", slug="ps-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="PS Closure", slug="ps-closure")
+        role = DeviceRole.objects.create(name="PS Role", slug="ps-role")
+        cls.closure = Device.objects.create(name="PS-Closure", site=site, device_type=dt, role=role)
+        cls.far_end = Device.objects.create(name="PS-FarEnd", site=site, device_type=dt, role=role)
+
+        mt = ModuleType.objects.create(manufacturer=mfr, model="PS Tray")
+        bay1 = ModuleBay.objects.create(device=cls.closure, name="Bay 1")
+        bay2 = ModuleBay.objects.create(device=cls.closure, name="Bay 2")
+        cls.tray1 = Module.objects.create(device=cls.closure, module_bay=bay1, module_type=mt)
+        cls.tray2 = Module.objects.create(device=cls.closure, module_bay=bay2, module_type=mt)
+
+        fct = FiberCableType.objects.create(manufacturer=mfr, model="PS-2F", construction="loose_tube", strand_count=2)
+        cls.fiber_cable = FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
+        cls.tube = BufferTube.objects.create(fiber_cable=cls.fiber_cable, name="PS-T1", position=1)
+        ClosureCableEntry.objects.create(closure=cls.closure, fiber_cable=cls.fiber_cable, entrance_label="G1")
+
+        cls.near_ports = []
+        cls.far_ports = []
+        for strand in cls.fiber_cable.fiber_strands.all().order_by("position"):
+            near = make_front_port(device=cls.closure, name=f"PS-N{strand.position}")
+            far = make_front_port(device=cls.far_end, name=f"PS-F{strand.position}")
+            strand.buffer_tube = cls.tube
+            strand.front_port_a = near
+            strand.front_port_b = far
+            strand.save()
+            cls.near_ports.append(near)
+            cls.far_ports.append(far)
+
+    def _assignment(self, tray=None, save=True):
+        ta = TubeAssignment(closure=self.closure, tray=tray or self.tray1, buffer_tube=self.tube)
+        if save:
+            ta.save()
+        return ta
+
+    def _refresh_ports(self):
+        for port in self.near_ports + self.far_ports:
+            port.refresh_from_db()
+
+
+class TestSyncHelpers(PortSyncTestCase):
+    def test_sync_places_closure_side_ports_on_tray(self):
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)
+        self._refresh_ports()
+        assert all(p.module_id == self.tray1.pk for p in self.near_ports)
+
+    def test_sync_leaves_far_end_ports_alone(self):
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)
+        self._refresh_ports()
+        assert all(p.module_id is None for p in self.far_ports)
+
+    def test_sync_tolerates_strands_without_ports(self):
+        FiberStrand.objects.create(fiber_cable=self.fiber_cable, buffer_tube=self.tube, name="PS-S3", position=3)
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)  # must not raise
+
+    def test_clear_returns_ports_to_device_level(self):
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)
+        clear_tube_assignment_ports(self.closure.pk, self.tray1.pk, self.tube.pk)
+        self._refresh_ports()
+        assert all(p.module_id is None for p in self.near_ports)
+
+    def test_clear_leaves_manually_moved_port_alone(self):
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)
+        moved = self.near_ports[0]
+        moved.module = self.tray2
+        moved.save()
+        clear_tube_assignment_ports(self.closure.pk, self.tray1.pk, self.tube.pk)
+        self._refresh_ports()
+        assert self.near_ports[0].module_id == self.tray2.pk
+        assert self.near_ports[1].module_id is None
+
+
+class TestConflictDetection(PortSyncTestCase):
+    def test_no_conflicts_for_device_level_ports(self):
+        ta = self._assignment(save=False)
+        assert ta.conflicting_front_ports() == []
+
+    def test_port_on_foreign_module_conflicts(self):
+        port = self.near_ports[0]
+        port.module = self.tray2
+        port.save()
+        ta = self._assignment(save=False)
+        assert ta.conflicting_front_ports() == [port]
+
+    def test_own_current_tray_is_not_a_conflict(self):
+        ta = self._assignment()
+        sync_tube_assignment_ports(ta)
+        ta.tray = self.tray2  # retargeting; ports sit on tray1, the DB tray
+        assert ta.conflicting_front_ports() == []
+
+    def test_target_tray_is_not_a_conflict(self):
+        port = self.near_ports[0]
+        port.module = self.tray1
+        port.save()
+        ta = self._assignment(save=False)
+        assert ta.conflicting_front_ports() == []


### PR DESCRIPTION
## Summary
- TubeAssignment becomes the producer of `FrontPort.module`: assigning a buffer tube to a splice tray places the tube's closure-side strand front ports on that tray module -- the placement every consumer already assumed (`SplicePlanEntry.tray` "owns fiber_a", the splice-state reader only sees ports on tray modules, the circuit wizard infers trays from `front_port.module`) but nothing produced until now.
- Full sync: tray/tube/closure changes re-point the ports (pre_save clears the old tuple first); deleting the assignment returns ports to device level (including via the ClosureCableEntry deletion cascade and bulk deletes). Only ports still on the assignment's tray are cleared, so manual placements survive.
- Conflicts (a port already on a foreign module) block the standard form, CSV import, and REST serializer with the named ports until a write-only `confirm_reassign` flag is set. Ports move via per-port snapshot+save so NetBox change logging records every move.

## Changes
- netbox_fms/services.py: `_tube_assignment_target_ports`, `sync_tube_assignment_ports`, `clear_tube_assignment_ports`
- netbox_fms/models.py: `TubeAssignment.conflicting_front_ports()`
- netbox_fms/signals.py: pre_save/post_save/post_delete receivers registered in `connect_signals()`
- netbox_fms/forms.py: `confirm_reassign` + shared conflict gate on TubeAssignmentForm and TubeAssignmentImportForm
- netbox_fms/api/serializers.py: write-only `confirm_reassign` popped in validate(); partial updates fall back to instance values
- tests/test_tube_assignment_port_sync.py: 21 tests -- helpers, conflict detection, signal lifecycle (create/tray change/tube change/delete/bulk delete), form/import/serializer gates incl. PATCH fallback
- CHANGELOG.md + user guides: behavior, conflict confirmation, backfill note (pre-existing assignments sync on re-save), tray-deletion caveat

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (520 passed, full suite on a fresh test DB)
- [x] New behavior covered by tests (TDD red-first per task)
- [x] No migration (no schema change; confirm_reassign is form/API-only)
- [x] Docs updated (CHANGELOG, splice-planning and device-fiber-overview guides)

## Screenshots / output
Form-level change is a new "Confirm reassignment" checkbox on the Tube Assignment form; no screenshot captured in this environment.

## Related
Fixes #68