### PR TITLE
feat(filters): chain Closure Entry cable dropdown on terminations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parent type's standard (position-ordered, with an "Other" fallback
   group). Fixes #60.
 
+- `terminated_device_id` filter on FiberCable (REST API and UI): cables with
+  a dcim termination on the given device. The Closure Cable Entry form's
+  Fiber Cable dropdown now chains on the selected Closure so only cables
+  physically terminated at that closure are offered. (#92)
+
 ### Changed
 
 - Import forms now declare choice fields as `CSVChoiceField` (`construction`

--- a/netbox_fms/filters.py
+++ b/netbox_fms/filters.py
@@ -188,6 +188,12 @@ class FiberCableFilterSet(SearchFieldsMixin, NetBoxModelFilterSet):
         field_name="installed_by",
         label=_("Installed by (ID)"),
     )
+    terminated_device_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Device.objects.all(),
+        field_name="cable__terminations___device",
+        label=_("Terminated at device (ID)"),
+        distinct=True,
+    )
 
     search_fields = (
         "serial_number__icontains",
@@ -198,7 +204,15 @@ class FiberCableFilterSet(SearchFieldsMixin, NetBoxModelFilterSet):
 
     class Meta:
         model = FiberCable
-        fields = ("id", "cable_id", "fiber_cable_type_id", "serial_number", "install_date", "installed_by_id")
+        fields = (
+            "id",
+            "cable_id",
+            "fiber_cable_type_id",
+            "serial_number",
+            "install_date",
+            "installed_by_id",
+            "terminated_device_id",
+        )
 
 
 class BufferTubeFilterSet(SearchFieldsMixin, NetBoxModelFilterSet):

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -767,7 +767,11 @@ class ClosureCableEntryForm(NetBoxModelForm):
     """Form for creating/editing a ClosureCableEntry."""
 
     closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"))
-    fiber_cable = DynamicModelChoiceField(queryset=FiberCable.objects.all(), label=_("Fiber Cable"))
+    fiber_cable = DynamicModelChoiceField(
+        queryset=FiberCable.objects.all(),
+        label=_("Fiber Cable"),
+        query_params={"terminated_device_id": "$closure"},
+    )
 
     fieldsets = (
         FieldSet("closure", "fiber_cable", "entrance_label", name=_("Cable Entry")),

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -605,10 +605,15 @@ class FiberCableFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label=_("Installed by"),
     )
+    terminated_device_id = DynamicModelMultipleChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        label=_("Terminated at device"),
+    )
 
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("fiber_cable_type_id", "installed_by_id", name=_("Attributes")),
+        FieldSet("fiber_cable_type_id", "installed_by_id", "terminated_device_id", name=_("Attributes")),
     )
 
 

--- a/tests/test_closure_entry_cable_filter.py
+++ b/tests/test_closure_entry_cable_filter.py
@@ -1,0 +1,56 @@
+"""Tests for filtering fiber cables by terminated device (issue #92)."""
+
+from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Manufacturer, RearPort, Site
+from django.test import TestCase
+
+from netbox_fms.filters import FiberCableFilterSet
+from netbox_fms.forms import ClosureCableEntryForm
+from netbox_fms.models import FiberCable, FiberCableType
+
+
+class TestFiberCableTerminatedDeviceFilter(TestCase):
+    """FiberCableFilterSet.terminated_device_id narrows cables to those terminated at a device (#92)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="CEF Site", slug="cef-site")
+        mfr = Manufacturer.objects.create(name="CEF Mfr", slug="cef-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="CEF Closure", slug="cef-closure")
+        role = DeviceRole.objects.create(name="CEF Role", slug="cef-role")
+        cls.closure_a = Device.objects.create(name="CEF-A", site=site, device_type=dt, role=role)
+        cls.closure_b = Device.objects.create(name="CEF-B", site=site, device_type=dt, role=role)
+
+        fct = FiberCableType.objects.create(
+            manufacturer=mfr, model="CEF-12F", construction="loose_tube", strand_count=12
+        )
+
+        rp_a = RearPort.objects.create(device=cls.closure_a, name="CEF-RP-A", type="splice", positions=12)
+        rp_b = RearPort.objects.create(device=cls.closure_b, name="CEF-RP-B", type="splice", positions=12)
+
+        cable_a = Cable.objects.create()
+        CableTermination.objects.create(cable=cable_a, cable_end="A", termination=rp_a)
+        cls.fc_terminated = FiberCable.objects.create(cable=cable_a, fiber_cable_type=fct)
+
+        cable_b = Cable.objects.create()
+        CableTermination.objects.create(cable=cable_b, cable_end="A", termination=rp_b)
+        cls.fc_elsewhere = FiberCable.objects.create(cable=cable_b, fiber_cable_type=fct)
+
+        cls.fc_unterminated = FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
+
+    def test_filter_returns_only_cables_terminated_at_device(self):
+        qs = FiberCableFilterSet({"terminated_device_id": [self.closure_a.pk]}, queryset=FiberCable.objects.all()).qs
+        assert set(qs) == {self.fc_terminated}
+
+    def test_unfiltered_returns_all(self):
+        qs = FiberCableFilterSet({}, queryset=FiberCable.objects.all()).qs
+        assert {self.fc_terminated, self.fc_elsewhere, self.fc_unterminated} <= set(qs)
+
+    def test_both_ends_terminated_at_device_not_duplicated(self):
+        rp_a2 = RearPort.objects.create(device=self.closure_a, name="CEF-RP-A2", type="splice", positions=12)
+        CableTermination.objects.create(cable=self.fc_terminated.cable, cable_end="B", termination=rp_a2)
+        qs = FiberCableFilterSet({"terminated_device_id": [self.closure_a.pk]}, queryset=FiberCable.objects.all()).qs
+        assert list(qs) == [self.fc_terminated]
+
+    def test_entry_form_chains_fiber_cable_on_closure(self):
+        field = ClosureCableEntryForm().fields["fiber_cable"]
+        assert field.query_params == {"terminated_device_id": "$closure"}

--- a/tests/test_closure_entry_cable_filter.py
+++ b/tests/test_closure_entry_cable_filter.py
@@ -31,19 +31,15 @@ class TestFiberCableTerminatedDeviceFilter(TestCase):
         CableTermination.objects.create(cable=cable_a, cable_end="A", termination=rp_a)
         cls.fc_terminated = FiberCable.objects.create(cable=cable_a, fiber_cable_type=fct)
 
+        # Negative cases for the filter: terminated at another closure, and no terminations at all.
         cable_b = Cable.objects.create()
         CableTermination.objects.create(cable=cable_b, cable_end="A", termination=rp_b)
-        cls.fc_elsewhere = FiberCable.objects.create(cable=cable_b, fiber_cable_type=fct)
-
-        cls.fc_unterminated = FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
+        FiberCable.objects.create(cable=cable_b, fiber_cable_type=fct)
+        FiberCable.objects.create(cable=Cable.objects.create(), fiber_cable_type=fct)
 
     def test_filter_returns_only_cables_terminated_at_device(self):
         qs = FiberCableFilterSet({"terminated_device_id": [self.closure_a.pk]}, queryset=FiberCable.objects.all()).qs
         assert set(qs) == {self.fc_terminated}
-
-    def test_unfiltered_returns_all(self):
-        qs = FiberCableFilterSet({}, queryset=FiberCable.objects.all()).qs
-        assert {self.fc_terminated, self.fc_elsewhere, self.fc_unterminated} <= set(qs)
 
     def test_both_ends_terminated_at_device_not_duplicated(self):
         rp_a2 = RearPort.objects.create(device=self.closure_a, name="CEF-RP-A2", type="splice", positions=12)


### PR DESCRIPTION
## Summary
- The Closure Cable Entry form's Fiber Cable dropdown listed every FiberCable; it now only offers cables physically terminated at the closure selected in the Closure dropdown.
- Implemented as a `terminated_device_id` filter on FiberCableFilterSet using the `cable__terminations___device` traversal suggested by @DanSheps in #86 (CableTermination's denormalized `_device`), chained on the form via `query_params={"terminated_device_id": "$closure"}`. Also exposed in the FiberCable list view's filter panel and on the REST API list endpoint.
- Complementary to #86: the Tube Assignment form filters via ClosureCableEntry to mirror `TubeAssignment.clean()`'s validation, while here the entry cannot exist yet, so physical terminations are the right source.

## Changes
- netbox_fms/filters.py: `terminated_device_id` ModelMultipleChoiceFilter on FiberCableFilterSet (distinct, in Meta.fields)
- netbox_fms/forms.py: ClosureCableEntryForm.fiber_cable gains the query_params chain; FiberCableFilterForm gains a Terminated at device control
- tests/test_closure_entry_cable_filter.py: filter narrowing, both-ends dedup, form chaining (TDD red-first)
- CHANGELOG.md: entry under [Unreleased] > Added

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] pytest passes locally (full suite on main merged with this branch: 526 passed)
- [x] New behavior covered by tests
- [x] No migration
- [x] CHANGELOG updated

## Screenshots / output
Selecting a Closure narrows the Fiber Cable dropdown to cables terminated at that closure; no screenshot captured in this environment.

## Related
Fixes #92
Refs #86