### PR TITLE
fix(map): link slack loop map details to the object page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Slack Loops layer on the netbox-pathways interactive map now declares a
+  `url_template`, so the map sidebar's detail pane shows a "View Details" link
+  to the slack loop instance. Refs jsenecal/netbox-pathways#81.
 - Bulk edit forms no longer silently overwrite choice fields that were left
   untouched: `construction`, `sheath_material`, `deployment`, `fire_rating`,
   and `mark_unit` on FiberCableType, `element_type` on CableElementTemplate,

--- a/netbox_fms/__init__.py
+++ b/netbox_fms/__init__.py
@@ -83,6 +83,7 @@ class NetBoxFMSConfig(PluginConfig):
             popover_fields=["name", "fiber_cable"],
             style=LayerStyle(color="#ff9800", icon="mdi-rotate-right"),
             detail=LayerDetail(
+                url_template="/plugins/fms/slack-loops/{id}/",
                 fields=["name", "site", "fiber_cable", "loop_length", "storage_method"],
                 label_field="name",
             ),


### PR DESCRIPTION
## Summary
- The Slack Loops layer registered with netbox-pathways declared detail fields but no `url_template`, so the interactive map's sidebar had no object page to link to.
- Declare `/plugins/fms/slack-loops/{id}/` so the sidebar renders its "View Details" button for slack loops.
- Companion to jsenecal/netbox-pathways#85, which fixes the sidebar crash that made external point features (slack loops, splice closures) unselectable in the first place.

## Changes
- `netbox_fms/__init__.py`: add `url_template` to the `fms_slack_loops` `LayerDetail`.
- `CHANGELOG.md`: entry under `[Unreleased]` > Fixed.

## Testing
- [x] `ruff check` passes
- [x] Registration metadata only -- no behavior change inside netbox-fms itself
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Refs jsenecal/netbox-pathways#81
