### PR TITLE
fix(api): enforce object permissions in custom API views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only the first module's front ports and reported a spurious count
   mismatch. (#64)
 
+### Security
+
+- Four custom API views bypassed NetBox object-level permissions. The
+  fiber-circuit-nodes viewset and the fiber-circuits/protecting view
+  ignored `ObjectPermission` constraints, serving every row to any user
+  with a model-level view permission; the fiber-claims and
+  closure-strands views required only authentication, disclosing splice
+  plans, strand maps, and circuit names to users with no permissions at
+  all. All querysets feeding those responses are now restricted to the
+  requesting user's permitted objects, matching the enforcement the
+  `NetBoxModelViewSet`-based endpoints have always had. Reported
+  alongside jsenecal/netbox-pathways#123.
+
 ## [0.2.0] - 2026-05-26
 
 ### Added

--- a/netbox_fms/api/views.py
+++ b/netbox_fms/api/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
-from ..choices import FiberCircuitStatusChoices, SplicePlanStatusChoices
+from ..choices import SplicePlanStatusChoices
 from ..filters import (
     BufferTubeFilterSet,
     BufferTubeTemplateFilterSet,
@@ -57,7 +57,7 @@ from ..models import (
     TrayProfile,
     TubeAssignment,
 )
-from ..services import apply_diff, get_or_recompute_diff, import_live_state
+from ..services import apply_diff, get_or_recompute_diff, import_live_state, protecting_nodes
 from ..trace_hops import build_hops
 from .serializers import (
     BufferTubeSerializer,
@@ -339,12 +339,7 @@ class SplicePlanViewSet(NetBoxModelViewSet):
             all_port_ids.add(item["fiber_b"])
 
         if all_port_ids:
-            protected_nodes = (
-                FiberCircuitNode.objects.filter(front_port_id__in=all_port_ids)
-                .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
-                .select_related("path__circuit")
-            )
-            protected_names = {n.path.circuit.name for n in protected_nodes}
+            protected_names = {n.path.circuit.name for n in protecting_nodes(all_port_ids)}
             if protected_names:
                 names = ", ".join(sorted(protected_names))
                 return Response(
@@ -611,12 +606,7 @@ def _get_protected_plan_ports(plan):
         fp_ids.add(entry.fiber_b_id)
     if not fp_ids:
         return {}
-    protected_nodes = (
-        FiberCircuitNode.objects.filter(front_port_id__in=fp_ids)
-        .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
-        .select_related("path__circuit")
-    )
-    return {n.front_port_id: n.path.circuit.name for n in protected_nodes}
+    return {n.front_port_id: n.path.circuit.name for n in protecting_nodes(fp_ids)}
 
 
 class ClosureStrandsAPIView(APIView):
@@ -736,13 +726,7 @@ class ClosureStrandsAPIView(APIView):
         # A front port is "protected" if referenced by a non-decommissioned FiberCircuitNode
         protection_lookup = {}  # front_port_id -> (circuit_name, circuit_url)
         if all_tray_fp_ids:
-            protected_nodes = (
-                FiberCircuitNode.objects.restrict(user, "view")
-                .filter(front_port_id__in=all_tray_fp_ids)
-                .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
-                .select_related("path__circuit")
-            )
-            for node in protected_nodes:
+            for node in protecting_nodes(all_tray_fp_ids, user=user):
                 circuit = node.path.circuit
                 protection_lookup[node.front_port_id] = (circuit.name, circuit.get_absolute_url())
 

--- a/netbox_fms/api/views.py
+++ b/netbox_fms/api/views.py
@@ -528,6 +528,11 @@ class FiberCircuitNodeViewSet(ModelViewSet):
     serializer_class = FiberCircuitNodeSerializer
     http_method_names = ["get", "head", "options"]
 
+    def get_queryset(self):
+        # Plain DRF viewsets skip NetBox's object-permission enforcement;
+        # apply the same restriction NetBoxModelViewSet would.
+        return super().get_queryset().restrict(self.request.user, "view")
+
 
 class FiberCircuitProtectingAPIView(APIView):
     """Return circuits protecting the given objects."""
@@ -550,7 +555,7 @@ class FiberCircuitProtectingAPIView(APIView):
                 filters |= models.Q(**{f"{field}__in": ids})
         if not filters:
             return Response([])
-        circuits = FiberCircuit.objects.filter(filters).distinct()
+        circuits = FiberCircuit.objects.restrict(request.user, "view").filter(filters).distinct()
         serializer = FiberCircuitSerializer(circuits, many=True, context={"request": request})
         return Response(serializer.data)
 
@@ -568,7 +573,8 @@ class FiberClaimsAPIView(APIView):
     def get(self, request, device_id):
         """Return fiber claims for all non-archived plans on the given closure device."""
         qs = (
-            SplicePlanEntry.objects.filter(plan__closure_id=device_id)
+            SplicePlanEntry.objects.restrict(request.user, "view")
+            .filter(plan__closure_id=device_id)
             .exclude(plan__status=SplicePlanStatusChoices.ARCHIVED)
             .select_related("plan__project")
         )
@@ -620,9 +626,15 @@ class ClosureStrandsAPIView(APIView):
 
     def get(self, request, device_id):
         """Return strands grouped by cable and tube for the given closure device."""
+        # Every queryset whose rows reach the response is restricted to the
+        # requesting user's object permissions; ID-only structural lookups
+        # (front ports, cable terminations) stay unrestricted since they
+        # only ever key into restricted data.
+        user = request.user
+
         # Build tube assignment lookup: buffer_tube_id -> {tray_id, tray_name}
         tube_assignment_lookup = {}
-        for ta in TubeAssignment.objects.filter(closure_id=device_id).select_related("tray"):
+        for ta in TubeAssignment.objects.restrict(user, "view").filter(closure_id=device_id).select_related("tray"):
             tube_assignment_lookup[ta.buffer_tube_id] = {
                 "tray_id": ta.tray_id,
                 "tray_name": str(ta.tray),
@@ -639,7 +651,11 @@ class ClosureStrandsAPIView(APIView):
             .distinct()
         )
 
-        fiber_cables = FiberCable.objects.filter(cable_id__in=cable_ids).select_related("cable", "fiber_cable_type")
+        fiber_cables = (
+            FiberCable.objects.restrict(user, "view")
+            .filter(cable_id__in=cable_ids)
+            .select_related("cable", "fiber_cable_type")
+        )
 
         # Build far-end device lookup: cable_id -> (device_name, device_url)
         far_end_lookup = {}
@@ -647,7 +663,7 @@ class ClosureStrandsAPIView(APIView):
         for term in all_terms:
             if term._device_id and term._device_id != device_id:
                 try:
-                    far_dev = Device.objects.get(pk=term._device_id)
+                    far_dev = Device.objects.restrict(user, "view").get(pk=term._device_id)
                     far_end_lookup[term.cable_id] = {
                         "id": far_dev.pk,
                         "name": str(far_dev),
@@ -687,28 +703,42 @@ class ClosureStrandsAPIView(APIView):
         plan_lookup = {}
         plan_id = request.query_params.get("plan_id")
         if plan_id:
-            plan_entries = SplicePlanEntry.objects.filter(
-                plan_id=plan_id,
-            ).values_list("id", "fiber_a_id", "fiber_b_id")
+            plan_entries = (
+                SplicePlanEntry.objects.restrict(user, "view")
+                .filter(plan_id=plan_id)
+                .values_list("id", "fiber_a_id", "fiber_b_id")
+            )
             for entry_id, fa_id, fb_id in plan_entries:
                 if fa_id in tray_front_port_ids and fb_id in tray_front_port_ids:
                     plan_lookup[fa_id] = (entry_id, fb_id)
                     plan_lookup[fb_id] = (entry_id, fa_id)
 
-        # --- C) Build protection lookup: front_port_id → circuit name ---
-        # A front port is "protected" if referenced by a non-decommissioned FiberCircuitNode
-        all_tray_fp_ids = set()
-        for fc in fiber_cables:
-            for s in fc.fiber_strands.all():
-                if s.front_port_a_id:
-                    all_tray_fp_ids.add(s.front_port_a_id)
-                if s.front_port_b_id:
-                    all_tray_fp_ids.add(s.front_port_b_id)
+        # Materialize each cable's viewable strands once; the lookups below and
+        # the cable groups all consume this same restricted set.
+        strands_by_cable = {
+            fc.pk: list(
+                fc.fiber_strands.restrict(user, "view").select_related("buffer_tube", "ribbon").order_by("position")
+            )
+            for fc in fiber_cables
+        }
 
+        # --- C) Build front_port_id → strand_id reverse mapping ---
+        fp_to_strand = {}
+        for strands in strands_by_cable.values():
+            for s in strands:
+                if s.front_port_a_id:
+                    fp_to_strand[s.front_port_a_id] = s.pk
+                if s.front_port_b_id:
+                    fp_to_strand[s.front_port_b_id] = s.pk
+        all_tray_fp_ids = set(fp_to_strand)
+
+        # --- D) Build protection lookup: front_port_id → circuit name ---
+        # A front port is "protected" if referenced by a non-decommissioned FiberCircuitNode
         protection_lookup = {}  # front_port_id -> (circuit_name, circuit_url)
         if all_tray_fp_ids:
             protected_nodes = (
-                FiberCircuitNode.objects.filter(front_port_id__in=all_tray_fp_ids)
+                FiberCircuitNode.objects.restrict(user, "view")
+                .filter(front_port_id__in=all_tray_fp_ids)
                 .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
                 .select_related("path__circuit")
             )
@@ -716,18 +746,9 @@ class ClosureStrandsAPIView(APIView):
                 circuit = node.path.circuit
                 protection_lookup[node.front_port_id] = (circuit.name, circuit.get_absolute_url())
 
-        # --- D) Build front_port_id → strand_id reverse mapping ---
-        fp_to_strand = {}
-        for fc in fiber_cables:
-            for s in fc.fiber_strands.all():
-                if s.front_port_a_id:
-                    fp_to_strand[s.front_port_a_id] = s.pk
-                if s.front_port_b_id:
-                    fp_to_strand[s.front_port_b_id] = s.pk
-
         cable_groups = []
         for fc in fiber_cables:
-            strands = fc.fiber_strands.select_related("buffer_tube", "ribbon").order_by("position")
+            strands = strands_by_cable[fc.pk]
 
             # Group strands by tube
             tubes_dict = OrderedDict()
@@ -800,7 +821,7 @@ class ClosureStrandsAPIView(APIView):
 
         # Build trays list
         trays = []
-        for m in Module.objects.filter(device_id=device_id).select_related("module_type"):
+        for m in Module.objects.restrict(user, "view").filter(device_id=device_id).select_related("module_type"):
             profile = getattr(m.module_type, "tray_profile", None)
             if profile:
                 trays.append(
@@ -815,7 +836,7 @@ class ClosureStrandsAPIView(APIView):
         # Include plan version for optimistic locking
         plan_version = None
         if plan_id:
-            plan_obj = SplicePlan.objects.filter(pk=plan_id).first()
+            plan_obj = SplicePlan.objects.restrict(user, "view").filter(pk=plan_id).first()
             if plan_obj and plan_obj.last_updated:
                 plan_version = plan_obj.last_updated.isoformat()
 

--- a/netbox_fms/models.py
+++ b/netbox_fms/models.py
@@ -1968,6 +1968,11 @@ class FiberCircuitPath(NetBoxModel):
 class FiberCircuitNode(models.Model):
     """Relational index of objects in a fiber circuit path for PROTECT-based deletion prevention."""
 
+    # Not a NetBoxModel, so wire up the restricted manager explicitly --
+    # the API exposes this model and must be able to enforce object
+    # permissions on it via .restrict().
+    objects = RestrictedQuerySet.as_manager()
+
     path = models.ForeignKey(
         to="netbox_fms.FiberCircuitPath",
         on_delete=models.CASCADE,

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -4,7 +4,8 @@ from dcim.models import Cable, CableTermination, Device, FrontPort, Module, Modu
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
-from .models import ClosureCableEntry, FiberCable, SplicePlanEntry
+from .choices import FiberCircuitStatusChoices
+from .models import ClosureCableEntry, FiberCable, FiberCircuitNode, SplicePlanEntry
 from .signals import fms_portmapping_bypass
 
 
@@ -424,6 +425,26 @@ def import_live_state(plan):
     plan.diff_stale = True
     plan.save(update_fields=["diff_stale"])
     return len(entries)
+
+
+def protecting_nodes(front_port_ids, user=None):
+    """
+    FiberCircuitNodes on active (non-decommissioned) circuits referencing
+    the given front ports.
+
+    Integrity checks (blocking edits to circuit-protected splices) must
+    leave ``user`` unset so every circuit counts regardless of the
+    requesting user's permissions; display contexts pass ``user`` to
+    restrict the rows to that user's visible objects.
+    """
+    qs = FiberCircuitNode.objects.all()
+    if user is not None:
+        qs = qs.restrict(user, "view")
+    return (
+        qs.filter(front_port_id__in=front_port_ids)
+        .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
+        .select_related("path__circuit")
+    )
 
 
 def apply_diff(plan):

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -17,7 +17,7 @@ from netbox.object_actions import BulkDelete, BulkEdit, DeleteObject, EditObject
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 
-from .choices import FiberCircuitStatusChoices, SplicePlanStatusChoices, TrayRoleChoices
+from .choices import SplicePlanStatusChoices, TrayRoleChoices
 from .export import generate_drawio
 from .filters import (
     BufferTubeFilterSet,
@@ -128,6 +128,7 @@ from .services import (
     get_or_recompute_diff,
     import_live_state,
     link_cable_topology,
+    protecting_nodes,
 )
 from .tables import (
     BufferTubeTable,
@@ -2206,11 +2207,7 @@ class DevicePendingWorkView(generic.ObjectView):
                         fp_ids.add(entry.fiber_a_id)
                         fp_ids.add(entry.fiber_b_id)
                 if fp_ids:
-                    protected_circuits = set(
-                        FiberCircuitNode.objects.filter(front_port_id__in=fp_ids)
-                        .exclude(path__circuit__status=FiberCircuitStatusChoices.DECOMMISSIONED)
-                        .values_list("path__circuit__name", flat=True)
-                    )
+                    protected_circuits = set(protecting_nodes(fp_ids).values_list("path__circuit__name", flat=True))
                     if protected_circuits:
                         names = ", ".join(sorted(protected_circuits))
                         messages.error(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,16 @@
-from dcim.models import FrontPort
+from dcim.models import DeviceRole, DeviceType, FrontPort, Manufacturer, Site
 
 # Counter to ensure unique FrontPort names across tests (no longer needed but kept for safety)
 _fp_counter = 0
+
+
+def make_infra(prefix):
+    """Create the site/manufacturer/device-type/role quartet most fixtures need."""
+    site = Site.objects.create(name=f"{prefix} Site", slug=f"{prefix.lower()}-site")
+    mfr = Manufacturer.objects.create(name=f"{prefix} Mfr", slug=f"{prefix.lower()}-mfr")
+    dt = DeviceType.objects.create(manufacturer=mfr, model=f"{prefix} FOSC", slug=f"{prefix.lower()}-fosc")
+    role = DeviceRole.objects.create(name=f"{prefix} Closure", slug=f"{prefix.lower()}-closure")
+    return site, mfr, dt, role
 
 
 def make_front_port(device, name, module=None, port_type="lc"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,14 +2,10 @@
 
 from dcim.models import (
     Device,
-    DeviceRole,
-    DeviceType,
     FrontPort,
-    Manufacturer,
     Module,
     ModuleBay,
     ModuleType,
-    Site,
 )
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -21,6 +17,7 @@ from netbox_fms.models import (
     SplicePlan,
     SplicePlanEntry,
 )
+from tests.conftest import make_infra
 
 
 def _make_authed_client():
@@ -32,15 +29,6 @@ def _make_authed_client():
     return client
 
 
-def _make_base_infra(prefix="t"):
-    """Create site, manufacturer, device type, role. Return (site, mfr, dt, role)."""
-    site = Site.objects.create(name=f"{prefix} Site", slug=f"{prefix}-site")
-    mfr = Manufacturer.objects.create(name=f"{prefix} Mfr", slug=f"{prefix}-mfr")
-    dt = DeviceType.objects.create(manufacturer=mfr, model=f"{prefix} DT", slug=f"{prefix}-dt")
-    role = DeviceRole.objects.create(name=f"{prefix} Role", slug=f"{prefix}-role")
-    return site, mfr, dt, role
-
-
 # ---------------------------------------------------------------------------
 # Existing bulk-update and quick-add tests
 # ---------------------------------------------------------------------------
@@ -49,10 +37,7 @@ def _make_base_infra(prefix="t"):
 class TestBulkUpdateAPI(TestCase):
     @classmethod
     def setUpTestData(cls):
-        site = Site.objects.create(name="API Site", slug="api-site")
-        mfr = Manufacturer.objects.create(name="API Mfr", slug="api-mfr")
-        dt = DeviceType.objects.create(manufacturer=mfr, model="Closure", slug="api-closure")
-        role = DeviceRole.objects.create(name="API Role", slug="api-role")
+        site, mfr, dt, role = make_infra("API")
         cls.closure = Device.objects.create(name="C-API", site=site, device_type=dt, role=role)
 
         mt = ModuleType.objects.create(manufacturer=mfr, model="Tray")
@@ -128,10 +113,7 @@ class TestBulkUpdateAPI(TestCase):
 class TestQuickAddAPI(TestCase):
     @classmethod
     def setUpTestData(cls):
-        site = Site.objects.create(name="QA Site", slug="qa-site")
-        mfr = Manufacturer.objects.create(name="QA Mfr", slug="qa-mfr")
-        dt = DeviceType.objects.create(manufacturer=mfr, model="Closure", slug="qa-closure")
-        role = DeviceRole.objects.create(name="QA Role", slug="qa-role")
+        site, mfr, dt, role = make_infra("QA")
         cls.closure = Device.objects.create(name="C-QA", site=site, device_type=dt, role=role)
 
     def setUp(self):
@@ -182,7 +164,7 @@ class TestFiberCircuitRetraceAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("retrace")
+        site, mfr, dt, role = make_infra("retrace")
         cls.device = Device.objects.create(name="Dev-Retrace", site=site, device_type=dt, role=role)
         cls.fp = FrontPort.objects.create(device=cls.device, name="FP-Origin", type="lc")
         cls.circuit = FiberCircuit.objects.create(name="FC-Retrace", strand_count=1, status="planned")
@@ -209,7 +191,7 @@ class TestFiberCircuitPathTraceAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("trace")
+        site, mfr, dt, role = make_infra("trace")
         cls.device = Device.objects.create(name="Dev-Trace", site=site, device_type=dt, role=role)
         cls.fp = FrontPort.objects.create(device=cls.device, name="FP-Trace", type="lc")
         cls.circuit = FiberCircuit.objects.create(name="FC-Trace", strand_count=1, status="planned")
@@ -267,7 +249,7 @@ class TestSplicePlanDiffAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("diff")
+        site, mfr, dt, role = make_infra("diff")
         cls.closure = Device.objects.create(name="C-Diff", site=site, device_type=dt, role=role)
         cls.plan = SplicePlan.objects.create(closure=cls.closure, name="Diff Plan")
 
@@ -290,7 +272,7 @@ class TestSplicePlanImportFromDeviceAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("imp")
+        site, mfr, dt, role = make_infra("imp")
         cls.closure = Device.objects.create(name="C-Import", site=site, device_type=dt, role=role)
         cls.plan = SplicePlan.objects.create(closure=cls.closure, name="Import Plan")
 
@@ -315,7 +297,7 @@ class TestSplicePlanApplyAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("apply")
+        site, mfr, dt, role = make_infra("apply")
         cls.closure = Device.objects.create(name="C-Apply", site=site, device_type=dt, role=role)
         cls.plan = SplicePlan.objects.create(closure=cls.closure, name="Apply Plan")
 
@@ -338,7 +320,7 @@ class TestClosureStrandsAPI(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("cstrands")
+        site, mfr, dt, role = make_infra("cstrands")
         cls.device = Device.objects.create(name="Closure-Strands", site=site, device_type=dt, role=role)
 
     def setUp(self):
@@ -443,7 +425,7 @@ class TestOptimisticLocking(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_base_infra("lock")
+        site, mfr, dt, role = make_infra("lock")
         cls.closure = Device.objects.create(name="C-Lock", site=site, device_type=dt, role=role)
 
         mt = ModuleType.objects.create(manufacturer=mfr, model="Lock Tray")

--- a/tests/test_api_object_permissions.py
+++ b/tests/test_api_object_permissions.py
@@ -26,6 +26,7 @@ from netbox_fms.models import (
     FiberCircuit,
     FiberCircuitNode,
     FiberCircuitPath,
+    FiberStrand,
     SplicePlan,
     SplicePlanEntry,
 )
@@ -34,8 +35,14 @@ from tests.conftest import make_infra
 User = get_user_model()
 
 
-def _constrained_client(model, constraints, username):
-    """API client for a user whose view permission on ``model`` carries ``constraints``."""
+def _constrained_client(models, constraints, username):
+    """API client for a user whose view permission on ``models`` carries ``constraints``.
+
+    ``models`` is a model class or a list of them; ``constraints=None`` grants
+    unconstrained view permission on those models.
+    """
+    if not isinstance(models, (list, tuple)):
+        models = [models]
     user = User.objects.create_user(username=username, password="x")  # noqa: S106
     perm = ObjectPermission.objects.create(
         name=f"perm-{username}",
@@ -43,7 +50,7 @@ def _constrained_client(model, constraints, username):
         actions=["view"],
         constraints=constraints,
     )
-    perm.object_types.set([ContentType.objects.get_for_model(model)])
+    perm.object_types.set([ContentType.objects.get_for_model(m) for m in models])
     perm.users.add(user)
     client = APIClient()
     # Re-fetch so no stale permission cache rides along on the user instance
@@ -131,18 +138,46 @@ class TestClaimsEndpointPermissions(TestCase):
 
 
 class TestClosureStrandsEndpointPermissions(TestCase):
-    """The closure-strands view must not serve cable/strand data the user cannot view."""
+    """The closure-strands view must serve exactly what the user may view: nothing
+    to a user without permissions, the full strand map to a permitted user."""
 
     @classmethod
     def setUpTestData(cls):
         site, mfr, dt, role = make_infra("PermS")
         cls.closure = Device.objects.create(name="PermS-1", site=site, device_type=dt, role=role)
+        cls.far_device = Device.objects.create(name="PermS-Far", site=site, device_type=dt, role=role)
         fp = FrontPort.objects.create(device=cls.closure, name="PermS-FP", type="lc")
-        cable = Cable.objects.create(a_terminations=[fp])
+        far_fp = FrontPort.objects.create(device=cls.far_device, name="PermS-Far-FP", type="lc")
+        cable = Cable.objects.create(a_terminations=[fp], b_terminations=[far_fp])
         fct = FiberCableType.objects.create(
             manufacturer=mfr, model="PermS-TB6", strand_count=6, construction="tight_buffer"
         )
-        FiberCable.objects.create(cable=cable, fiber_cable_type=fct)
+        fc = FiberCable.objects.create(cable=cable, fiber_cable_type=fct)
+
+        # Map one strand to the closure's front port and protect it with a
+        # circuit, so the protection lookup has a row to resolve.
+        cls.protected_strand = fc.fiber_strands.order_by("position").first()
+        cls.protected_strand.front_port_a = fp
+        cls.protected_strand.save()
+        circuit = FiberCircuit.objects.create(
+            name="PermS-Circuit",
+            status=FiberCircuitStatusChoices.ACTIVE,
+            strand_count=1,
+        )
+        path = FiberCircuitPath.objects.create(
+            circuit=circuit,
+            position=1,
+            origin=fp,
+            path=[{"type": "cable", "id": cable.pk}],
+            is_complete=False,
+        )
+        FiberCircuitNode.objects.create(path=path, position=1, front_port=fp)
+
+        cls.plan = SplicePlan.objects.create(
+            closure=cls.closure,
+            name="PermS-Plan",
+            status=SplicePlanStatusChoices.DRAFT,
+        )
 
     def test_strands_hidden_from_user_without_permission(self):
         client = _no_perm_client("perm-strands")
@@ -150,3 +185,22 @@ class TestClosureStrandsEndpointPermissions(TestCase):
         assert resp.status_code == 200
         assert resp.data["cables"] == []
         assert resp.data["trays"] == []
+
+    def test_strands_visible_to_permitted_user(self):
+        """The restriction must not hide data from a user who holds view permission."""
+        client = _constrained_client(
+            [FiberCable, FiberStrand, FiberCircuitNode, SplicePlan, Device],
+            None,
+            "perm-strands-ok",
+        )
+        resp = client.get(f"/api/plugins/fms/closure-strands/{self.closure.pk}/?plan_id={self.plan.pk}")
+        assert resp.status_code == 200
+        assert len(resp.data["cables"]) == 1
+        group = resp.data["cables"][0]
+        assert group["far_device_name"] == "PermS-Far"
+        strands = {s["id"]: s for s in group["loose_strands"]}
+        assert len(strands) == 6
+        protected = strands[self.protected_strand.pk]
+        assert protected["protected"] is True
+        assert protected["circuit_name"] == "PermS-Circuit"
+        assert resp.data["plan_version"] is not None

--- a/tests/test_api_object_permissions.py
+++ b/tests/test_api_object_permissions.py
@@ -1,0 +1,152 @@
+"""Regression tests for object-permission enforcement in the custom API views.
+
+Regression tests for the netbox_fms views flagged in
+jsenecal/netbox-pathways#123: views that bypassed NetBox object-level
+permissions by subclassing plain DRF classes or querying bare managers.
+"""
+
+from dcim.models import (
+    Cable,
+    Device,
+    FrontPort,
+    Module,
+    ModuleBay,
+    ModuleType,
+)
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from rest_framework.test import APIClient
+from users.models import ObjectPermission
+
+from netbox_fms.choices import FiberCircuitStatusChoices, SplicePlanStatusChoices
+from netbox_fms.models import (
+    FiberCable,
+    FiberCableType,
+    FiberCircuit,
+    FiberCircuitNode,
+    FiberCircuitPath,
+    SplicePlan,
+    SplicePlanEntry,
+)
+from tests.conftest import make_infra
+
+User = get_user_model()
+
+
+def _constrained_client(model, constraints, username):
+    """API client for a user whose view permission on ``model`` carries ``constraints``."""
+    user = User.objects.create_user(username=username, password="x")  # noqa: S106
+    perm = ObjectPermission.objects.create(
+        name=f"perm-{username}",
+        enabled=True,
+        actions=["view"],
+        constraints=constraints,
+    )
+    perm.object_types.set([ContentType.objects.get_for_model(model)])
+    perm.users.add(user)
+    client = APIClient()
+    # Re-fetch so no stale permission cache rides along on the user instance
+    client.force_authenticate(user=User.objects.get(pk=user.pk))
+    return client
+
+
+def _no_perm_client(username):
+    """API client for an authenticated user holding no permissions at all."""
+    user = User.objects.create_user(username=username, password="x")  # noqa: S106
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+class TestCircuitEndpointPermissions(TestCase):
+    """The circuit-node viewset and the protecting view must honour constraints."""
+
+    @classmethod
+    def setUpTestData(cls):
+        site, mfr, dt, role = make_infra("PermC")
+        device = Device.objects.create(name="PermC-1", site=site, device_type=dt, role=role)
+        fp = FrontPort.objects.create(device=device, name="PermC-FP", type="lc")
+        cls.cable = Cable.objects.create()
+
+        cls.nodes = {}
+        for name in ("Perm-A", "Perm-B"):
+            circuit = FiberCircuit.objects.create(
+                name=name,
+                status=FiberCircuitStatusChoices.ACTIVE,
+                strand_count=1,
+            )
+            path = FiberCircuitPath.objects.create(
+                circuit=circuit,
+                position=1,
+                origin=fp,
+                path=[{"type": "cable", "id": cls.cable.pk}],
+                is_complete=False,
+            )
+            cls.nodes[name] = FiberCircuitNode.objects.create(path=path, position=1, cable=cls.cable)
+
+    def test_circuit_nodes_list_honours_constraints(self):
+        client = _constrained_client(
+            FiberCircuitNode,
+            {"path__circuit__name": "Perm-A"},
+            "perm-nodes",
+        )
+        resp = client.get("/api/plugins/fms/fiber-circuit-nodes/")
+        assert resp.status_code == 200
+        ids = {r["id"] for r in resp.data["results"]}
+        assert ids == {self.nodes["Perm-A"].pk}
+
+    def test_protecting_view_honours_constraints(self):
+        client = _constrained_client(FiberCircuit, {"name": "Perm-A"}, "perm-protecting")
+        resp = client.get(f"/api/plugins/fms/fiber-circuits/protecting/?cable={self.cable.pk}")
+        assert resp.status_code == 200
+        names = {c["name"] for c in resp.data}
+        assert names == {"Perm-A"}
+
+
+class TestClaimsEndpointPermissions(TestCase):
+    """The fiber-claims view must not serve plan entries the user cannot view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        site, mfr, dt, role = make_infra("PermF")
+        cls.closure = Device.objects.create(name="PermF-1", site=site, device_type=dt, role=role)
+        mt = ModuleType.objects.create(manufacturer=mfr, model="PermF Tray")
+        mb = ModuleBay.objects.create(device=cls.closure, name="Bay 1", position="1")
+        tray = Module.objects.create(device=cls.closure, module_bay=mb, module_type=mt)
+        fa = FrontPort.objects.create(device=cls.closure, module=tray, name="PermF-A", type="lc")
+        fb = FrontPort.objects.create(device=cls.closure, module=tray, name="PermF-B", type="lc")
+        plan = SplicePlan.objects.create(
+            closure=cls.closure,
+            name="PermF-Plan",
+            status=SplicePlanStatusChoices.DRAFT,
+        )
+        SplicePlanEntry.objects.create(plan=plan, tray=tray, fiber_a=fa, fiber_b=fb)
+
+    def test_claims_hidden_from_user_without_permission(self):
+        client = _no_perm_client("perm-claims")
+        resp = client.get(f"/api/plugins/fms/closures/{self.closure.pk}/fiber-claims/")
+        assert resp.status_code == 200
+        assert resp.data == []
+
+
+class TestClosureStrandsEndpointPermissions(TestCase):
+    """The closure-strands view must not serve cable/strand data the user cannot view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        site, mfr, dt, role = make_infra("PermS")
+        cls.closure = Device.objects.create(name="PermS-1", site=site, device_type=dt, role=role)
+        fp = FrontPort.objects.create(device=cls.closure, name="PermS-FP", type="lc")
+        cable = Cable.objects.create(a_terminations=[fp])
+        fct = FiberCableType.objects.create(
+            manufacturer=mfr, model="PermS-TB6", strand_count=6, construction="tight_buffer"
+        )
+        FiberCable.objects.create(cable=cable, fiber_cable_type=fct)
+
+    def test_strands_hidden_from_user_without_permission(self):
+        client = _no_perm_client("perm-strands")
+        resp = client.get(f"/api/plugins/fms/closure-strands/{self.closure.pk}/")
+        assert resp.status_code == 200
+        assert resp.data["cables"] == []
+        assert resp.data["trays"] == []

--- a/tests/test_closure_cable_flow.py
+++ b/tests/test_closure_cable_flow.py
@@ -6,13 +6,9 @@ from dcim.models import (
     Cable,
     CableTermination,
     Device,
-    DeviceRole,
-    DeviceType,
     FrontPort,
-    Manufacturer,
     PortMapping,
     RearPort,
-    Site,
 )
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -23,20 +19,13 @@ from netbox_fms.constants import FIBER_CABLE_TYPES
 from netbox_fms.forms import ClosureCableWizardStep1Form, ClosureCableWizardStep2Form
 from netbox_fms.models import BufferTubeTemplate, ClosureCableEntry, FiberCable, FiberCableType
 from netbox_fms.services import create_closure_cable
-
-
-def _make_infra(prefix):
-    site = Site.objects.create(name=f"{prefix} Site", slug=f"{prefix.lower()}-site")
-    mfr = Manufacturer.objects.create(name=f"{prefix} Mfr", slug=f"{prefix.lower()}-mfr")
-    dt = DeviceType.objects.create(manufacturer=mfr, model=f"{prefix} FOSC", slug=f"{prefix.lower()}-fosc")
-    role = DeviceRole.objects.create(name=f"{prefix} Closure", slug=f"{prefix.lower()}-closure")
-    return site, mfr, dt, role
+from tests.conftest import make_infra
 
 
 class TestCreateClosureCable(TestCase):
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_infra("CCF")
+        site, mfr, dt, role = make_infra("CCF")
         cls.device_a = Device.objects.create(name="CCF-A", site=site, device_type=dt, role=role)
         cls.device_b = Device.objects.create(name="CCF-B", site=site, device_type=dt, role=role)
         # tight buffer 6F -> builtin profile "single-1c6p"
@@ -163,7 +152,7 @@ class TestCreateClosureCable(TestCase):
 class TestClosureCableWizardForms(TestCase):
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_infra("WF")
+        site, mfr, dt, role = make_infra("WF")
         cls.device_a = Device.objects.create(name="WF-A", site=site, device_type=dt, role=role)
         cls.device_b = Device.objects.create(name="WF-B", site=site, device_type=dt, role=role)
         cls.fct = FiberCableType.objects.create(
@@ -199,7 +188,7 @@ class TestClosureCableWizardForms(TestCase):
 class TestClosureCableWizardView(TestCase):
     @classmethod
     def setUpTestData(cls):
-        site, mfr, dt, role = _make_infra("WV")
+        site, mfr, dt, role = make_infra("WV")
         cls.device_a = Device.objects.create(name="WV-A", site=site, device_type=dt, role=role)
         cls.device_b = Device.objects.create(name="WV-B", site=site, device_type=dt, role=role)
         cls.fct = FiberCableType.objects.create(

--- a/tests/test_pending_work_apply.py
+++ b/tests/test_pending_work_apply.py
@@ -3,22 +3,19 @@
 from unittest.mock import patch
 
 import pytest
-from dcim.models import Cable, Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from dcim.models import Cable, Device, Module, ModuleBay, ModuleType
 from django.contrib.auth import get_user_model
 
 from netbox_fms.choices import FiberCircuitStatusChoices, SplicePlanStatusChoices
 from netbox_fms.models import FiberCircuit, FiberCircuitNode, FiberCircuitPath, SplicePlan, SplicePlanEntry
-from tests.conftest import make_front_port
+from tests.conftest import make_front_port, make_infra
 
 User = get_user_model()
 
 
 def _build_closure_with_plan(prefix, plan_status=SplicePlanStatusChoices.APPROVED):
     """Create a closure with one tray, two front ports, and one splice plan entry."""
-    site = Site.objects.create(name=f"{prefix} Site", slug=f"{prefix.lower()}-site")
-    mfr = Manufacturer.objects.create(name=f"{prefix} Mfr", slug=f"{prefix.lower()}-mfr")
-    dt = DeviceType.objects.create(manufacturer=mfr, model=f"{prefix} Closure", slug=f"{prefix.lower()}-closure")
-    role = DeviceRole.objects.create(name=f"{prefix} Role", slug=f"{prefix.lower()}-role")
+    site, mfr, dt, role = make_infra(prefix)
     closure = Device.objects.create(name=f"{prefix}-Closure", site=site, device_type=dt, role=role)
 
     mt = ModuleType.objects.create(manufacturer=mfr, model=f"{prefix} Tray")


### PR DESCRIPTION
## Summary
- Four custom API views (fiber-circuit-nodes viewset, fiber-circuits/protecting, fiber-claims, closure-strands) bypassed NetBox object-level permissions by subclassing plain DRF classes or querying bare managers, disclosing splice plans, strand maps, and circuit names beyond the requesting user's ObjectPermission constraints.
- Every queryset feeding those responses is now restricted with .restrict(user, "view"), matching the enforcement the NetBoxModelViewSet-based endpoints have always had. ID-only structural lookups (front ports, cable terminations) stay unrestricted since they only key into restricted data.
- FiberCircuitNode is a plain Model, so it gains a RestrictedQuerySet manager to make .restrict() available.

## Changes
- netbox_fms/api/views.py: restrict all response-feeding querysets in the four affected views; build the per-cable strand map once instead of iterating strands three times
- netbox_fms/models.py: RestrictedQuerySet manager on FiberCircuitNode
- netbox_fms/services.py: new protecting_nodes() helper centralizing the protecting-circuit-nodes query previously duplicated in four places; the optional user argument makes the restricted (display) vs unrestricted (integrity check) split explicit
- netbox_fms/views.py: pending-work apply uses protecting_nodes()
- tests/test_api_object_permissions.py: regression tests with constrained and permissionless users across the four endpoints
- tests/conftest.py: shared make_infra fixture helper (extracted from test_closure_cable_flow)
- tests/test_api.py, tests/test_pending_work_apply.py, tests/test_closure_cable_flow.py: fold duplicate infra factories into make_infra
- CHANGELOG.md: Security entry under Unreleased

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (75 passed across the touched test modules, fresh test DB)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG)

## Related
Refs: jsenecal/netbox-pathways#123