### PR TITLE
feat(forms): add object selector to wizard device pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Device pickers in the wizard flows (closure cable wizard far end device,
+  circuit wizard origin/destination devices, slack loop insertion closure)
+  now offer NetBox's object selector popup, allowing devices to be found
+  by site, location, rack, and other filters instead of scrolling a flat
+  list of all devices. Fixes #88.
 - Splice closure creation wizard: **FMS > Add Splice Closure** creates the
   closure Device with named "Tray 1..N" module bays, tray modules, and
   optional express basket bays in one atomic action. Requires tray

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -1025,8 +1025,12 @@ class CircuitWizardStep1Form(forms.Form):
 class CircuitWizardStep2Form(forms.Form):
     """Step 2: Select origin and destination devices."""
 
-    origin_device = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Origin Device"))
-    destination_device = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Destination Device"))
+    origin_device = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Origin Device"), selector=True)
+    destination_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        label=_("Destination Device"),
+        selector=True,
+    )
 
     def clean(self):
         super().clean()
@@ -1091,6 +1095,7 @@ class InsertSlackLoopForm(forms.Form):
         queryset=Device.objects.all(),
         label=_("Closure"),
         help_text=_("Target splice closure device."),
+        selector=True,
     )
     a_side_rear_ports = DynamicModelMultipleChoiceField(
         queryset=RearPort.objects.all(),
@@ -1308,6 +1313,7 @@ class ClosureCableWizardStep1Form(forms.Form):
         queryset=Device.objects.all(),
         label=_("Far end device"),
         help_text=_("The closure or device at the other end of the cable."),
+        selector=True,
     )
     fiber_cable_type = DynamicModelChoiceField(
         queryset=FiberCableType.objects.all(),

--- a/tests/test_closure_cable_flow.py
+++ b/tests/test_closure_cable_flow.py
@@ -16,7 +16,12 @@ from django.test import TestCase
 from django.urls import reverse
 
 from netbox_fms.constants import FIBER_CABLE_TYPES
-from netbox_fms.forms import ClosureCableWizardStep1Form, ClosureCableWizardStep2Form
+from netbox_fms.forms import (
+    CircuitWizardStep2Form,
+    ClosureCableWizardStep1Form,
+    ClosureCableWizardStep2Form,
+    InsertSlackLoopForm,
+)
 from netbox_fms.models import BufferTubeTemplate, ClosureCableEntry, FiberCable, FiberCableType
 from netbox_fms.services import create_closure_cable
 from tests.conftest import make_infra
@@ -173,6 +178,16 @@ class TestClosureCableWizardForms(TestCase):
             near_device=self.device_a,
         )
         assert form.is_valid(), form.errors
+
+    def test_wizard_device_fields_enable_object_selector(self):
+        """Regression test for issue #88: wizard device pickers offer the
+        object selector popup so duplicate device names across sites can be
+        disambiguated by site/location/rack filters."""
+        assert ClosureCableWizardStep1Form(near_device=self.device_a).fields["far_end_device"].selector
+        step2 = CircuitWizardStep2Form()
+        assert step2.fields["origin_device"].selector
+        assert step2.fields["destination_device"].selector
+        assert InsertSlackLoopForm().fields["closure"].selector
 
     def test_step2_type_choices_are_fiber_only(self):
         values = {value for value, _label in ClosureCableWizardStep2Form().fields["type"].choices if value}


### PR DESCRIPTION
## Summary
- Device pickers in the wizard flows showed a flat list of all devices, making same-named devices across sites (e.g. ODF1 at two sites) impossible to tell apart.
- Enable NetBox's object selector (the same filter popup DCIM's Cable Add form uses) on the wizard device fields so users can narrow by site/location/rack before picking.

## Changes
- netbox_fms/forms.py: selector=True on ClosureCableWizardStep1Form.far_end_device, CircuitWizardStep2Form.origin_device and destination_device, and InsertSlackLoopForm.closure. The htmx modal container these popups require is already present on every affected page via the generic base templates, so no template changes are needed.
- tests/test_closure_cable_flow.py: targeted test asserting all four wizard device fields enable the selector.
- CHANGELOG.md: entry under Unreleased.

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (28 tests across the three affected wizard/insert suites)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG; README/docs do not document individual widgets)

## Related
Fixes: #88