### PR TITLE
feat(choices): add DIN IEC 60304 fiber color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- DIN IEC 60304 fiber color scheme -- `FiberCableType.color_scheme` now
+  offers the German DIN VDE 0888 fiber sequence (Red, Green, Blue, Yellow,
+  White, Grey, Brown, Violet, Turquoise, Black, Orange, Pink) alongside
+  EIA/TIA-598 and ABNT NBR 14771. The default is unchanged. Refs #107.
+
 - Splice closure creation wizard: **FMS > Add Splice Closure** creates the
   closure Device with named "Tray 1..N" module bays, tray modules, and
   optional express basket bays in one atomic action. Requires tray

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Define fiber cable construction as reusable blueprints, auto-instantiate compone
 
 - **Cable type blueprints with auto-instantiation** -- Define fiber cable construction once as a FiberCableType, then create instances that automatically populate buffer tubes, ribbons, strands, and cable elements following NetBox's Device/DeviceType pattern.
 - **Four construction cases** -- Loose tube, ribbon-in-tube, central-core ribbon, and tight buffer cable designs with full template-driven instantiation.
-- **EIA/TIA-598 and ABNT NBR 14771 color schemes** -- Each FiberCableType selects the strand color standard applied when instances are created; tube and ribbon template color pickers follow the selected standard.
+- **EIA/TIA-598, ABNT NBR 14771, and DIN IEC 60304 color schemes** -- Each FiberCableType selects the strand color standard applied when instances are created; tube and ribbon template color pickers follow the selected standard.
 - **Per-wavelength loss budgeting** -- Attach manufacturer max-attenuation specs (dB/km) to each FiberCableType at any wavelength. `FiberCircuitPath.calculated_loss_db` computes per-wavelength losses across the full cable path from spec values and each cable's `glass_length`.
 - **Splice planning** -- Map strand-to-strand connections in splice closures, compute diffs against live state, and export diagrams to draw.io for field crews.
 - **Fiber circuit provisioning** -- End-to-end provisioning with DAG-based pathfinding and multi-hop tracing.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -195,6 +195,10 @@ modules.
   Red, Black, Yellow, Violet, Rose, Aqua).
 - **`NBR_14771_COLORS`** -- Tuple of 12 `(hex_color, name)` pairs following the
   ABNT NBR-14771 Brazilian standard (same colors, different position order).
+- **`DIN_IEC_60304_COLORS`** -- Tuple of 12 `(hex_color, name)` pairs following
+  the German DIN VDE 0888 fiber sequence built on the IEC 60304 color set
+  (Red, Green, Blue, Yellow, White, Grey, Brown, Violet, Turquoise, Black,
+  Orange, Pink).
 - **`COLOR_SCHEME_PALETTES`** -- Dict mapping scheme choices to color tuples,
   enabling multi-standard support.
 - **`get_strand_color(position, scheme)`** -- Returns the color tuple for a

--- a/docs/user-guide/fiber-cable-types.md
+++ b/docs/user-guide/fiber-cable-types.md
@@ -38,22 +38,23 @@ standard used to color-identify strands inside the cable. When a
 FiberCable of this type is created, strand colors are assigned
 automatically following the selected standard. Pick the scheme that
 matches the manufacturer's market: `EIA/TIA-598` (default) for most
-international plant, `ABNT NBR 14771` for Brazilian plant.
+international plant, `ABNT NBR 14771` for Brazilian plant,
+`DIN IEC 60304` (the DIN VDE 0888 fiber sequence) for German plant.
 
-| Position | EIA/TIA-598 | ABNT NBR 14771 |
-|----------|-------------|----------------|
-| 1        | Blue        | Green          |
-| 2        | Orange      | Yellow         |
-| 3        | Green       | White          |
-| 4        | Brown       | Blue           |
-| 5        | Slate       | Red            |
-| 6        | White       | Violet         |
-| 7        | Red         | Brown          |
-| 8        | Black       | Rose           |
-| 9        | Yellow      | Black          |
-| 10       | Violet      | Gray           |
-| 11       | Rose        | Orange         |
-| 12       | Aqua        | Aqua           |
+| Position | EIA/TIA-598 | ABNT NBR 14771 | DIN IEC 60304 |
+|----------|-------------|----------------|---------------|
+| 1        | Blue        | Green          | Red           |
+| 2        | Orange      | Yellow         | Green         |
+| 3        | Green       | White          | Blue          |
+| 4        | Brown       | Blue           | Yellow        |
+| 5        | Slate       | Red            | White         |
+| 6        | White       | Violet         | Grey          |
+| 7        | Red         | Brown          | Brown         |
+| 8        | Black       | Rose           | Violet        |
+| 9        | Yellow      | Black          | Turquoise     |
+| 10       | Violet      | Gray           | Black         |
+| 11       | Rose        | Orange         | Orange        |
+| 12       | Aqua        | Aqua           | Pink          |
 
 Positions beyond 12 cycle through the palette again (position 13 repeats
 position 1); use strand markers to distinguish repeats.

--- a/netbox_fms/choices.py
+++ b/netbox_fms/choices.py
@@ -31,10 +31,12 @@ class FiberColorSchemeChoices(ChoiceSet):
 
     EIA_598 = "eia_598"
     NBR_14771 = "nbr_14771"
+    DIN_IEC_60304 = "din_iec_60304"
 
     CHOICES = (
         (EIA_598, "EIA/TIA-598"),
         (NBR_14771, "ABNT NBR 14771"),
+        (DIN_IEC_60304, "DIN IEC 60304"),
     )
 
 

--- a/netbox_fms/constants.py
+++ b/netbox_fms/constants.py
@@ -39,9 +39,30 @@ NBR_14771_COLORS = (
     ("00ffff", "Aqua"),
 )
 
+
+# DIN VDE 0888 fiber color code (German standard), built on the IEC 60304
+# insulated-core color set. Same 12 hexes as EIA-598 in a different order;
+# positions 6, 9, and 12 are named "Grey", "Turquoise", and "Pink" but
+# share the EIA Slate, Aqua, and Rose hexes.
+DIN_IEC_60304_COLORS = (
+    ("ff0000", "Red"),
+    ("00ff00", "Green"),
+    ("0000ff", "Blue"),
+    ("ffff00", "Yellow"),
+    ("ffffff", "White"),
+    ("708090", "Grey"),
+    ("8b4513", "Brown"),
+    ("ee82ee", "Violet"),
+    ("00ffff", "Turquoise"),
+    ("000000", "Black"),
+    ("ff8000", "Orange"),
+    ("ff69b4", "Pink"),
+)
+
 COLOR_SCHEME_PALETTES = {
     FiberColorSchemeChoices.EIA_598: EIA_598_COLORS,
     FiberColorSchemeChoices.NBR_14771: NBR_14771_COLORS,
+    FiberColorSchemeChoices.DIN_IEC_60304: DIN_IEC_60304_COLORS,
 }
 
 

--- a/tests/test_color_schemes.py
+++ b/tests/test_color_schemes.py
@@ -4,6 +4,7 @@ from dcim.models import Cable, Manufacturer
 from netbox_fms.choices import FiberColorSchemeChoices
 from netbox_fms.constants import (
     COLOR_SCHEME_PALETTES,
+    DIN_IEC_60304_COLORS,
     EIA_598_COLORS,
     NBR_14771_COLORS,
     get_grouped_color_choices,
@@ -29,11 +30,13 @@ class TestFiberColorSchemeChoices:
     def test_values(self):
         assert FiberColorSchemeChoices.EIA_598 == "eia_598"
         assert FiberColorSchemeChoices.NBR_14771 == "nbr_14771"
+        assert FiberColorSchemeChoices.DIN_IEC_60304 == "din_iec_60304"
 
     def test_labels(self):
         labels = dict(FiberColorSchemeChoices.CHOICES)
         assert str(labels["eia_598"]) == "EIA/TIA-598"
         assert str(labels["nbr_14771"]) == "ABNT NBR 14771"
+        assert str(labels["din_iec_60304"]) == "DIN IEC 60304"
 
 
 class TestGetStrandColor:
@@ -55,16 +58,37 @@ class TestGetStrandColor:
         got = [get_strand_color(pos, FiberColorSchemeChoices.NBR_14771) for pos in range(1, 13)]
         assert got == expected
 
+    def test_din_full_sequence(self):
+        """DIN VDE 0888 fiber sequence built on the IEC 60304 color set. Refs #107."""
+        expected = [
+            ("ff0000", "Red"),
+            ("00ff00", "Green"),
+            ("0000ff", "Blue"),
+            ("ffff00", "Yellow"),
+            ("ffffff", "White"),
+            ("708090", "Grey"),
+            ("8b4513", "Brown"),
+            ("ee82ee", "Violet"),
+            ("00ffff", "Turquoise"),
+            ("000000", "Black"),
+            ("ff8000", "Orange"),
+            ("ff69b4", "Pink"),
+        ]
+        got = [get_strand_color(pos, FiberColorSchemeChoices.DIN_IEC_60304) for pos in range(1, 13)]
+        assert got == expected
+
     def test_eia_position_one_is_blue(self):
         assert get_strand_color(1, FiberColorSchemeChoices.EIA_598) == ("0000ff", "Blue")
 
     def test_wraparound_past_twelve(self):
         assert get_strand_color(13, FiberColorSchemeChoices.NBR_14771) == ("00ff00", "Green")
         assert get_strand_color(13, FiberColorSchemeChoices.EIA_598) == ("0000ff", "Blue")
+        assert get_strand_color(13, FiberColorSchemeChoices.DIN_IEC_60304) == ("ff0000", "Red")
 
     def test_palette_registry(self):
         assert COLOR_SCHEME_PALETTES[FiberColorSchemeChoices.EIA_598] is EIA_598_COLORS
         assert COLOR_SCHEME_PALETTES[FiberColorSchemeChoices.NBR_14771] is NBR_14771_COLORS
+        assert COLOR_SCHEME_PALETTES[FiberColorSchemeChoices.DIN_IEC_60304] is DIN_IEC_60304_COLORS
 
 
 def _make_type(model, construction, strand_count, scheme=None):
@@ -104,6 +128,18 @@ class TestColorSchemeInstantiation:
         fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
         assert _strand_colors(fc) == [hex_color for hex_color, _name in NBR_14771_COLORS]
 
+    def test_tight_buffer_din(self):
+        """Strand colors under the DIN scheme at instantiation. Refs #107."""
+        fct = _make_type("DIN-4F-TB", "tight_buffer", 4, FiberColorSchemeChoices.DIN_IEC_60304)
+        fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
+        assert _strand_colors(fc) == ["ff0000", "00ff00", "0000ff", "ffff00"]
+
+    def test_loose_tube_din(self):
+        fct = _make_type("DIN-12F-LT", "loose_tube", 12, FiberColorSchemeChoices.DIN_IEC_60304)
+        BufferTubeTemplate.objects.create(fiber_cable_type=fct, name="T1", position=1, color="ff0000", fiber_count=12)
+        fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
+        assert _strand_colors(fc) == [hex_color for hex_color, _name in DIN_IEC_60304_COLORS]
+
     def test_ribbon_nbr(self):
         fct = _make_type("NBR-12F-RB", "ribbon", 12, FiberColorSchemeChoices.NBR_14771)
         RibbonTemplate.objects.create(fiber_cable_type=fct, name="R1", position=1, fiber_count=12)
@@ -125,9 +161,9 @@ class TestGroupedColorChoices:
         assert len(options) == 12
         assert str(groups[1][0]) == "Other"
 
-    def test_unknown_scheme_yields_both_standards(self):
+    def test_unknown_scheme_yields_all_standards(self):
         groups = get_grouped_color_choices(None)
-        assert [str(g[0]) for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "Other"]
+        assert [str(g[0]) for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
 
     def test_other_group_excludes_standard_hexes(self):
         groups = get_grouped_color_choices(FiberColorSchemeChoices.EIA_598)
@@ -157,9 +193,9 @@ class TestSchemeAwareColorPicker:
         groups = _picker_groups(BufferTubeTemplateForm(initial={"fiber_cable_type": fct.pk}))
         assert groups[0][0] == "ABNT NBR 14771"
 
-    def test_add_form_without_parent_shows_both_standards(self):
+    def test_add_form_without_parent_shows_all_standards(self):
         groups = _picker_groups(BufferTubeTemplateForm())
-        assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "Other"]
+        assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
 
     def test_off_palette_current_value_stays_selectable(self):
         fct = _make_type("NBR-PICKER-OFF", "loose_tube", 12, FiberColorSchemeChoices.NBR_14771)
@@ -176,10 +212,10 @@ class TestSchemeAwareColorPicker:
         groups = _picker_groups(RibbonTemplateForm(instance=rt))
         assert groups[0][0] == "ABNT NBR 14771"
 
-    def test_bulk_edit_forms_show_both_standards(self):
+    def test_bulk_edit_forms_show_all_standards(self):
         for form_cls in (BufferTubeTemplateBulkEditForm, RibbonTemplateBulkEditForm):
             groups = _picker_groups(form_cls())
-            assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "Other"]
+            assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
 
 
 @pytest.mark.django_db

--- a/tests/test_color_schemes.py
+++ b/tests/test_color_schemes.py
@@ -25,6 +25,10 @@ from netbox_fms.models import (
     RibbonTemplate,
 )
 
+# Expected optgroup labels when no single scheme is selected: every known
+# standard in registry order, then the generic fallback group.
+ALL_SCHEME_GROUP_LABELS = ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
+
 
 class TestFiberColorSchemeChoices:
     def test_values(self):
@@ -40,41 +44,50 @@ class TestFiberColorSchemeChoices:
 
 
 class TestGetStrandColor:
-    def test_nbr_full_sequence(self):
-        expected = [
-            ("00ff00", "Green"),
-            ("ffff00", "Yellow"),
-            ("ffffff", "White"),
-            ("0000ff", "Blue"),
-            ("ff0000", "Red"),
-            ("ee82ee", "Violet"),
-            ("8b4513", "Brown"),
-            ("ff69b4", "Rose"),
-            ("000000", "Black"),
-            ("708090", "Gray"),
-            ("ff8000", "Orange"),
-            ("00ffff", "Aqua"),
-        ]
-        got = [get_strand_color(pos, FiberColorSchemeChoices.NBR_14771) for pos in range(1, 13)]
-        assert got == expected
-
-    def test_din_full_sequence(self):
-        """DIN VDE 0888 fiber sequence built on the IEC 60304 color set. Refs #107."""
-        expected = [
-            ("ff0000", "Red"),
-            ("00ff00", "Green"),
-            ("0000ff", "Blue"),
-            ("ffff00", "Yellow"),
-            ("ffffff", "White"),
-            ("708090", "Grey"),
-            ("8b4513", "Brown"),
-            ("ee82ee", "Violet"),
-            ("00ffff", "Turquoise"),
-            ("000000", "Black"),
-            ("ff8000", "Orange"),
-            ("ff69b4", "Pink"),
-        ]
-        got = [get_strand_color(pos, FiberColorSchemeChoices.DIN_IEC_60304) for pos in range(1, 13)]
+    @pytest.mark.parametrize(
+        ("scheme", "expected"),
+        [
+            pytest.param(
+                FiberColorSchemeChoices.NBR_14771,
+                [
+                    ("00ff00", "Green"),
+                    ("ffff00", "Yellow"),
+                    ("ffffff", "White"),
+                    ("0000ff", "Blue"),
+                    ("ff0000", "Red"),
+                    ("ee82ee", "Violet"),
+                    ("8b4513", "Brown"),
+                    ("ff69b4", "Rose"),
+                    ("000000", "Black"),
+                    ("708090", "Gray"),
+                    ("ff8000", "Orange"),
+                    ("00ffff", "Aqua"),
+                ],
+                id="nbr_14771",
+            ),
+            pytest.param(
+                FiberColorSchemeChoices.DIN_IEC_60304,
+                [
+                    ("ff0000", "Red"),
+                    ("00ff00", "Green"),
+                    ("0000ff", "Blue"),
+                    ("ffff00", "Yellow"),
+                    ("ffffff", "White"),
+                    ("708090", "Grey"),
+                    ("8b4513", "Brown"),
+                    ("ee82ee", "Violet"),
+                    ("00ffff", "Turquoise"),
+                    ("000000", "Black"),
+                    ("ff8000", "Orange"),
+                    ("ff69b4", "Pink"),
+                ],
+                id="din_iec_60304",
+            ),
+        ],
+    )
+    def test_full_sequence(self, scheme, expected):
+        """Each scheme's literal 12-color sequence is the oracle; DIN rows added for issue #107."""
+        got = [get_strand_color(pos, scheme) for pos in range(1, 13)]
         assert got == expected
 
     def test_eia_position_one_is_blue(self):
@@ -128,18 +141,6 @@ class TestColorSchemeInstantiation:
         fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
         assert _strand_colors(fc) == [hex_color for hex_color, _name in NBR_14771_COLORS]
 
-    def test_tight_buffer_din(self):
-        """Strand colors under the DIN scheme at instantiation. Refs #107."""
-        fct = _make_type("DIN-4F-TB", "tight_buffer", 4, FiberColorSchemeChoices.DIN_IEC_60304)
-        fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
-        assert _strand_colors(fc) == ["ff0000", "00ff00", "0000ff", "ffff00"]
-
-    def test_loose_tube_din(self):
-        fct = _make_type("DIN-12F-LT", "loose_tube", 12, FiberColorSchemeChoices.DIN_IEC_60304)
-        BufferTubeTemplate.objects.create(fiber_cable_type=fct, name="T1", position=1, color="ff0000", fiber_count=12)
-        fc = FiberCable.objects.create(fiber_cable_type=fct, cable=Cable.objects.create())
-        assert _strand_colors(fc) == [hex_color for hex_color, _name in DIN_IEC_60304_COLORS]
-
     def test_ribbon_nbr(self):
         fct = _make_type("NBR-12F-RB", "ribbon", 12, FiberColorSchemeChoices.NBR_14771)
         RibbonTemplate.objects.create(fiber_cable_type=fct, name="R1", position=1, fiber_count=12)
@@ -163,7 +164,7 @@ class TestGroupedColorChoices:
 
     def test_unknown_scheme_yields_all_standards(self):
         groups = get_grouped_color_choices(None)
-        assert [str(g[0]) for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
+        assert [str(g[0]) for g in groups] == ALL_SCHEME_GROUP_LABELS
 
     def test_other_group_excludes_standard_hexes(self):
         groups = get_grouped_color_choices(FiberColorSchemeChoices.EIA_598)
@@ -195,7 +196,7 @@ class TestSchemeAwareColorPicker:
 
     def test_add_form_without_parent_shows_all_standards(self):
         groups = _picker_groups(BufferTubeTemplateForm())
-        assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
+        assert [g[0] for g in groups] == ALL_SCHEME_GROUP_LABELS
 
     def test_off_palette_current_value_stays_selectable(self):
         fct = _make_type("NBR-PICKER-OFF", "loose_tube", 12, FiberColorSchemeChoices.NBR_14771)
@@ -215,7 +216,7 @@ class TestSchemeAwareColorPicker:
     def test_bulk_edit_forms_show_all_standards(self):
         for form_cls in (BufferTubeTemplateBulkEditForm, RibbonTemplateBulkEditForm):
             groups = _picker_groups(form_cls())
-            assert [g[0] for g in groups] == ["EIA/TIA-598", "ABNT NBR 14771", "DIN IEC 60304", "Other"]
+            assert [g[0] for g in groups] == ALL_SCHEME_GROUP_LABELS
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Networks documented to the DIN (IEC 60304) fiber color code could not use the plugin's color assignment, which only offered EIA/TIA-598 and ABNT NBR 14771.
- Adds DIN IEC 60304 (DIN VDE 0888 fiber sequence) as a selectable color scheme on FiberCableType. The default stays EIA/TIA-598, so existing data and behavior are untouched.

## Changes
- netbox_fms/choices.py: DIN_IEC_60304 choice on FiberColorSchemeChoices.
- netbox_fms/constants.py: DIN_IEC_60304_COLORS 12-color palette (Red, Green, Blue, Yellow, White, Grey, Brown, Violet, Turquoise, Black, Orange, Pink) registered in COLOR_SCHEME_PALETTES; the existing registry-driven lookup handles everything else, so forms, import, bulk edit, filters, tables, API, and GraphQL pick the scheme up with no wiring changes and no migration (verified with makemigrations --check).
- tests/test_color_schemes.py: DIN sequence, registry, and wraparound coverage; sequence tests parametrized across schemes.
- README.md, docs/user-guide/fiber-cable-types.md, docs/developer/architecture.md, CHANGELOG.md: scheme documented.

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (full suite 534 passed; color scheme module 23 passed after test refactor)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly (no schema change; ChoiceSet choices are not serialized into the migration)
- [x] Docs updated (README, CHANGELOG, zensical pages)

## Related
Fixes: #107