### PR TITLE
fix(api): gate splice plan apply on approval workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The splice plan apply endpoint
+  (`POST /api/plugins/fms/splice-plans/{id}/apply/`) no longer bypasses the
+  approval workflow. Applying now requires the plan to be in `approved`
+  status (other statuses get a 409 with an explanatory message) and the
+  requesting user to hold the `approve_spliceplan` permission (403
+  otherwise). The status gate is enforced in the `apply_diff()` service so
+  every apply path is covered, and the closure Pending Work batch apply now
+  requires `approve_spliceplan` as well. After a successful apply the plan
+  automatically transitions to `archived`, matching the batch apply
+  behavior. (#111)
+
 ### Added
 
 - Splice editor express support: the splice detail panel shows an Express

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -152,7 +152,9 @@ modules.
 - **`get_live_state(closure)`** / **`get_desired_state(plan)`** -- Query helpers
   that feed `compute_diff()`.
 - **`apply_diff(plan)`** -- Applies the computed diff to NetBox's `PortMapping`
-  table, creating and deleting mappings as needed.
+  table, creating and deleting mappings as needed. Refuses plans that are not
+  in `approved` status and archives the plan after a successful apply, so
+  every apply path honours the approval workflow.
 - **`import_live_state(plan)`** -- Imports the current live splice state into a
   plan's entries for documentation purposes.
 - **`link_cable_topology(cable, fiber_cable_type, device, ...)`** -- Atomic

--- a/docs/user-guide/splice-planning.md
+++ b/docs/user-guide/splice-planning.md
@@ -108,6 +108,7 @@ stateDiagram-v2
     pending_approval --> draft : reject
     pending_approval --> draft : withdraw
     approved --> draft : reopen (requires approve_spliceplan)
+    approved --> archived : apply (requires approve_spliceplan)
     draft --> archived : discard
     pending_approval --> archived : discard
     approved --> archived : discard
@@ -131,6 +132,7 @@ stateDiagram-v2
 | reject       | pending_approval      | draft              | User with `approve_spliceplan` permission          |
 | withdraw     | pending_approval      | draft              | The user recorded in `submitted_by`                |
 | reopen       | approved              | draft              | User with `approve_spliceplan` permission          |
+| apply        | approved              | archived           | User with `approve_spliceplan` permission          |
 | discard      | draft, pending_approval, approved | archived | Any user with edit access to the plan        |
 
 Archiving is irreversible. Use it to close out plans that will never be applied, rather than deleting them, so that the planning history is preserved.
@@ -211,9 +213,22 @@ This requirement applies to all entry saves regardless of the plan's status, alt
 
 ---
 
-## Batch Apply
+## Applying Plans
 
-Approved plans are not applied individually. Instead, applying happens from the closure device's **Pending Work** tab.
+Applying is gated by the approval workflow on every path: only plans in
+`approved` status can be applied, and the acting user must hold the
+`approve_spliceplan` permission. After a successful apply, the plan
+automatically transitions to `archived` so the planning history is
+preserved.
+
+Applying always executes the **full plan-vs-live diff** -- every splice the
+plan adds relative to the closure's current state is created and every
+splice the plan omits is removed. It is not limited to the splices changed
+in the most recent editing session.
+
+### Batch Apply (Pending Work tab)
+
+In the web interface, applying happens from the closure device's **Pending Work** tab.
 
 1. Navigate to the closure device in NetBox.
 2. Open the **Pending Work** tab.
@@ -228,6 +243,20 @@ The Apply All action:
 - Operates atomically: if any part of the operation fails, no changes are committed.
 
 After a successful apply, the plans involved are transitioned to `archived` to preserve the historical record.
+
+### API Apply (single plan)
+
+A single approved plan can also be applied through the REST API:
+
+```
+POST /api/plugins/fms/splice-plans/{id}/apply/
+```
+
+The endpoint enforces the same gating as the Pending Work tab: the plan
+must be `approved` (any other status returns HTTP 409 with an explanatory
+message) and the requesting user must hold both `change_spliceplan` and
+`approve_spliceplan` (HTTP 403 otherwise). On success the response reports
+the number of splices added and removed, and the plan is archived.
 
 ---
 

--- a/netbox_fms/api/views.py
+++ b/netbox_fms/api/views.py
@@ -57,7 +57,7 @@ from ..models import (
     TrayProfile,
     TubeAssignment,
 )
-from ..services import apply_diff, get_or_recompute_diff, import_live_state, protecting_nodes
+from ..services import PlanNotApplicable, apply_diff, get_or_recompute_diff, import_live_state, protecting_nodes
 from ..trace_hops import build_hops
 from .serializers import (
     BufferTubeSerializer,
@@ -259,13 +259,6 @@ class SplicePlanViewSet(NetBoxModelViewSet):
                 {"detail": "Applying a splice plan requires the approve_spliceplan permission."},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        if plan.status != SplicePlanStatusChoices.APPROVED:
-            return Response(
-                {
-                    "error": f"Cannot apply: plan is '{plan.get_status_display()}' -- only approved plans can be applied."
-                },
-                status=status.HTTP_409_CONFLICT,
-            )
         # Check for protected splices being modified
         protected = _get_protected_plan_ports(plan)
         if protected:
@@ -278,6 +271,8 @@ class SplicePlanViewSet(NetBoxModelViewSet):
         try:
             result = apply_diff(plan)
             return Response(result)
+        except PlanNotApplicable as e:
+            return Response({"error": " ".join(e.messages)}, status=status.HTTP_409_CONFLICT)
         except (ValueError, ValidationError) as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/netbox_fms/api/views.py
+++ b/netbox_fms/api/views.py
@@ -254,6 +254,18 @@ class SplicePlanViewSet(NetBoxModelViewSet):
                 {"detail": "You do not have permission to perform this action."},
                 status=status.HTTP_403_FORBIDDEN,
             )
+        if not request.user.has_perm("netbox_fms.approve_spliceplan"):
+            return Response(
+                {"detail": "Applying a splice plan requires the approve_spliceplan permission."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        if plan.status != SplicePlanStatusChoices.APPROVED:
+            return Response(
+                {
+                    "error": f"Cannot apply: plan is '{plan.get_status_display()}' -- only approved plans can be applied."
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
         # Check for protected splices being modified
         protected = _get_protected_plan_ports(plan)
         if protected:

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -2,9 +2,10 @@
 
 from dcim.models import Cable, CableTermination, Device, FrontPort, Module, ModuleBay, PortMapping, RearPort
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import transaction
 
-from .choices import FiberCircuitStatusChoices
+from .choices import FiberCircuitStatusChoices, SplicePlanStatusChoices
 from .models import ClosureCableEntry, FiberCable, FiberCircuitNode, SplicePlanEntry
 from .signals import fms_portmapping_bypass
 
@@ -449,9 +450,16 @@ def protecting_nodes(front_port_ids, user=None):
 
 def apply_diff(plan):
     """
-    Execute the diff: create cables for "add", delete cables for "remove".
-    Returns {"added": int, "removed": int}.
+    Execute the full plan-vs-live diff: create cables for "add", delete
+    cables for "remove". Only approved plans may be applied; the check
+    lives here so every apply path honours the approval workflow. On
+    success the plan is archived. Returns {"added": int, "removed": int}.
     """
+    if plan.status != SplicePlanStatusChoices.APPROVED:
+        raise ValidationError(
+            f"Cannot apply plan '{plan}': status is '{plan.status}' -- only approved plans can be applied."
+        )
+
     diff = compute_diff(plan)
 
     fp_ct = ContentType.objects.get_for_model(FrontPort)
@@ -514,8 +522,11 @@ def apply_diff(plan):
             )
             added += 1
 
+        # Archive the applied plan so it becomes a read-only historical record
+        plan.status = SplicePlanStatusChoices.ARCHIVED
+        plan.cached_diff = None
         plan.diff_stale = True
-        plan.save(update_fields=["diff_stale"])
+        plan.save(update_fields=["status", "cached_diff", "diff_stale"])
 
     return {"added": added, "removed": removed}
 

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -10,6 +10,10 @@ from .models import ClosureCableEntry, FiberCable, FiberCircuitNode, SplicePlanE
 from .signals import fms_portmapping_bypass
 
 
+class PlanNotApplicable(ValidationError):  # noqa: N818
+    """Raised when a splice plan is not in a status that allows applying."""
+
+
 class NeedsMappingConfirmation(Exception):  # noqa: N818
     """Raised when existing ports are found and need user confirmation."""
 
@@ -456,7 +460,7 @@ def apply_diff(plan):
     success the plan is archived. Returns {"added": int, "removed": int}.
     """
     if plan.status != SplicePlanStatusChoices.APPROVED:
-        raise ValidationError(
+        raise PlanNotApplicable(
             f"Cannot apply plan '{plan}': status is '{plan.status}' -- only approved plans can be applied."
         )
 

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -2198,6 +2198,10 @@ class DevicePendingWorkView(generic.ObjectView):
         """Apply all approved plans atomically."""
         device = get_object_or_404(Device, pk=pk)
 
+        if not request.user.has_perm("netbox_fms.approve_spliceplan"):
+            messages.error(request, _("Applying splice plans requires the approve_spliceplan permission."))
+            return redirect(device.get_absolute_url())
+
         try:
             with transaction.atomic():
                 # Lock the approved plans; select_for_update requires an
@@ -2238,15 +2242,10 @@ class DevicePendingWorkView(generic.ObjectView):
                     local_module_ids = set(Module.objects.filter(device=plan.closure).values_list("pk", flat=True))
                     plan.entries.exclude(tray_id__in=local_module_ids).delete()
 
+                    # apply_diff() archives each plan after a successful apply
                     result = apply_diff(plan)
                     total_added += result["added"]
                     total_removed += result["removed"]
-
-                    # Archive the plan
-                    plan.status = SplicePlanStatusChoices.ARCHIVED
-                    plan.cached_diff = None
-                    plan.diff_stale = True
-                    plan.save(update_fields=["status", "cached_diff", "diff_stale"])
 
             msg = _("Applied {added} additions and {removed} removals from {count} plan(s).").format(
                 added=total_added,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -288,29 +288,6 @@ class TestSplicePlanImportFromDeviceAPI(TestCase):
 
 
 # ---------------------------------------------------------------------------
-# SplicePlan apply action
-# ---------------------------------------------------------------------------
-
-
-class TestSplicePlanApplyAPI(TestCase):
-    """POST /api/plugins/fms/splice-plans/{pk}/apply/ should return 200."""
-
-    @classmethod
-    def setUpTestData(cls):
-        site, mfr, dt, role = make_infra("apply")
-        cls.closure = Device.objects.create(name="C-Apply", site=site, device_type=dt, role=role)
-        cls.plan = SplicePlan.objects.create(closure=cls.closure, name="Apply Plan")
-
-    def setUp(self):
-        self.client = _make_authed_client()
-
-    def test_apply_empty_plan_returns_200(self):
-        url = f"/api/plugins/fms/splice-plans/{self.plan.pk}/apply/"
-        resp = self.client.post(url, format="json")
-        assert resp.status_code == 200, resp.content
-
-
-# ---------------------------------------------------------------------------
 # ClosureStrands API
 # ---------------------------------------------------------------------------
 

--- a/tests/test_apply_approval_gating.py
+++ b/tests/test_apply_approval_gating.py
@@ -1,0 +1,152 @@
+"""Regression tests for issue #111: applying a splice plan must honour the
+approval workflow.
+
+The API apply action previously required only change_spliceplan and never
+checked plan status, so a draft plan could be applied straight to the live
+closure. Applying now requires an approved plan AND the approve_spliceplan
+permission, and a successful apply archives the plan.
+"""
+
+from dcim.models import Cable
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from rest_framework.test import APIClient
+from users.models import ObjectPermission
+
+from netbox_fms.choices import SplicePlanStatusChoices
+from netbox_fms.models import SplicePlan, SplicePlanEntry
+from netbox_fms.services import apply_diff
+from tests.conftest import make_closure_with_tray
+
+User = get_user_model()
+
+
+def _client_with_actions(username, actions):
+    """API client for a non-superuser holding the given SplicePlan actions."""
+    user = User.objects.create_user(username=username, password="x")  # noqa: S106
+    perm = ObjectPermission.objects.create(name=f"perm-{username}", actions=actions)
+    perm.object_types.add(ContentType.objects.get_for_model(SplicePlan))
+    perm.users.add(user)
+    client = APIClient()
+    # Re-fetch so no stale permission cache rides along on the user instance
+    client.force_authenticate(user=User.objects.get(pk=user.pk))
+    return client
+
+
+class TestApplyApprovalGatingAPI(TestCase):
+    """POST /api/plugins/fms/splice-plans/{pk}/apply/ gating (issue #111)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.rig = make_closure_with_tray("AAG")
+
+    def _make_plan(self, name, status, **kwargs):
+        plan = SplicePlan.objects.create(closure=self.rig.closure, name=name, status=status, **kwargs)
+        SplicePlanEntry.objects.create(
+            plan=plan,
+            tray=self.rig.tray,
+            fiber_a=self.rig.ports[0],
+            fiber_b=self.rig.ports[1],
+        )
+        return plan
+
+    def _apply(self, client, plan):
+        return client.post(f"/api/plugins/fms/splice-plans/{plan.pk}/apply/", format="json")
+
+    def test_apply_draft_plan_rejected(self):
+        """A draft plan cannot be applied, even by an approver."""
+        plan = self._make_plan("AAG Draft", SplicePlanStatusChoices.DRAFT)
+        client = _client_with_actions("aag-approver-draft", ["view", "add", "change", "approve"])
+
+        resp = self._apply(client, plan)
+
+        assert resp.status_code == 409, resp.content
+        assert "approved" in resp.json()["error"].lower()
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.DRAFT
+        assert Cable.objects.count() == 0
+
+    def test_apply_pending_approval_plan_rejected(self):
+        """A plan awaiting approval cannot be applied."""
+        submitter = User.objects.create_user(username="aag-submitter", password="x")  # noqa: S106
+        plan = self._make_plan(
+            "AAG Pending",
+            SplicePlanStatusChoices.PENDING_APPROVAL,
+            submitted_by=submitter,
+        )
+        client = _client_with_actions("aag-approver-pending", ["view", "add", "change", "approve"])
+
+        resp = self._apply(client, plan)
+
+        assert resp.status_code == 409, resp.content
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.PENDING_APPROVAL
+        assert Cable.objects.count() == 0
+
+    def test_apply_archived_plan_rejected(self):
+        """An archived plan cannot be re-applied."""
+        plan = self._make_plan("AAG Archived", SplicePlanStatusChoices.ARCHIVED)
+        client = _client_with_actions("aag-approver-archived", ["view", "add", "change", "approve"])
+
+        resp = self._apply(client, plan)
+
+        assert resp.status_code == 409, resp.content
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.ARCHIVED
+        assert Cable.objects.count() == 0
+
+    def test_apply_without_approve_permission_forbidden(self):
+        """change_spliceplan alone is not enough to apply an approved plan."""
+        plan = self._make_plan("AAG NoApprove", SplicePlanStatusChoices.APPROVED)
+        client = _client_with_actions("aag-editor", ["view", "add", "change"])
+
+        resp = self._apply(client, plan)
+
+        assert resp.status_code == 403, resp.content
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.APPROVED
+        assert Cable.objects.count() == 0
+
+    def test_apply_approved_plan_succeeds_and_archives(self):
+        """An approver applying an approved plan commits the diff and archives it."""
+        plan = self._make_plan("AAG Approved", SplicePlanStatusChoices.APPROVED)
+        client = _client_with_actions("aag-approver-ok", ["view", "add", "change", "approve"])
+
+        resp = self._apply(client, plan)
+
+        assert resp.status_code == 200, resp.content
+        assert resp.json() == {"added": 1, "removed": 0}
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.ARCHIVED
+        assert Cable.objects.count() == 1
+
+
+class TestApplyDiffStatusGate(TestCase):
+    """apply_diff() itself refuses non-approved plans (issue #111)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.rig = make_closure_with_tray("AAGS")
+
+    def test_apply_diff_rejects_draft_plan(self):
+        """The service layer blocks applying a draft plan on every code path."""
+        plan = SplicePlan.objects.create(
+            closure=self.rig.closure,
+            name="AAGS Draft",
+            status=SplicePlanStatusChoices.DRAFT,
+        )
+        SplicePlanEntry.objects.create(
+            plan=plan,
+            tray=self.rig.tray,
+            fiber_a=self.rig.ports[0],
+            fiber_b=self.rig.ports[1],
+        )
+
+        with self.assertRaises(ValidationError):
+            apply_diff(plan)
+
+        plan.refresh_from_db()
+        assert plan.status == SplicePlanStatusChoices.DRAFT
+        assert Cable.objects.count() == 0

--- a/tests/test_fiber_overview.py
+++ b/tests/test_fiber_overview.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 
 User = get_user_model()
 
+from netbox_fms.choices import SplicePlanStatusChoices
 from netbox_fms.models import ClosureCableEntry, FiberCable, FiberCableType, SplicePlan, SplicePlanEntry
 from netbox_fms.services import apply_diff, create_closure_cable
 from netbox_fms.views import _build_cable_rows, _device_has_modules_or_fiber_cables, _get_closure_cable_or_404
@@ -194,7 +195,13 @@ class TestFiberOverviewCableRows(TestCase):
         CableTermination.objects.create(cable=cls.fp_cable, cable_end="A", termination=cls.fp3)
         cls.fp_fiber_cable = FiberCable.objects.create(cable=cls.fp_cable, fiber_cable_type=cls.fct)
 
-        plan = SplicePlan.objects.create(closure=cls.closure, name="FO93 Plan")
+        # apply_diff only runs on approved plans, so the jumper this fixture
+        # needs can only be created from one.
+        plan = SplicePlan.objects.create(
+            closure=cls.closure,
+            name="FO93 Plan",
+            status=SplicePlanStatusChoices.APPROVED,
+        )
         SplicePlanEntry.objects.create(plan=plan, tray=cls.tray, fiber_a=cls.fp1, fiber_b=cls.fp2)
         assert apply_diff(plan)["added"] == 1
         cls.jumper = Cable.objects.exclude(pk__in=[cls.trunk.pk, cls.bare.pk, cls.fp_cable.pk]).get()

--- a/tests/test_pending_work_apply.py
+++ b/tests/test_pending_work_apply.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import pytest
 from dcim.models import Cable, Device, Module, ModuleBay, ModuleType
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from users.models import ObjectPermission
 
 from netbox_fms.choices import FiberCircuitStatusChoices, SplicePlanStatusChoices
 from netbox_fms.models import FiberCircuit, FiberCircuitNode, FiberCircuitPath, SplicePlan, SplicePlanEntry
@@ -45,6 +47,28 @@ def test_apply_all_without_approved_plans_errors(client):
     assert response.status_code == 302
     plan.refresh_from_db()
     assert plan.status == SplicePlanStatusChoices.DRAFT
+    assert Cable.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_apply_all_requires_approve_permission(client):
+    """A user without approve_spliceplan cannot batch-apply approved plans.
+
+    Regression test for issue #111: every apply path must be gated on the
+    approve_spliceplan permission, including the closure Pending Work view.
+    """
+    closure, plan, _fp = _build_closure_with_plan("PWNA")
+    user = User.objects.create_user(username="pwna-viewer", password="pw")  # noqa: S106
+    perm = ObjectPermission.objects.create(name="pwna-view-device", actions=["view"])
+    perm.object_types.add(ContentType.objects.get_for_model(Device))
+    perm.users.add(user)
+    client.force_login(user)
+
+    response = client.post(f"/dcim/devices/{closure.pk}/pending-work/")
+
+    assert response.status_code == 302
+    plan.refresh_from_db()
+    assert plan.status == SplicePlanStatusChoices.APPROVED
     assert Cable.objects.count() == 0
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,6 +13,7 @@ from dcim.models import (
 )
 from django.test import TestCase
 
+from netbox_fms.choices import SplicePlanStatusChoices
 from netbox_fms.models import SplicePlan, SplicePlanEntry
 from netbox_fms.services import (
     apply_diff,
@@ -211,7 +212,9 @@ class TestApplyDiff(TestCase):
         cls.fp4 = make_front_port(device=cls.closure, module=cls.tray, name="F4")
 
     def test_apply_creates_cables(self):
-        plan = SplicePlan.objects.create(closure=self.closure, name="Apply Plan")
+        plan = SplicePlan.objects.create(
+            closure=self.closure, name="Apply Plan", status=SplicePlanStatusChoices.APPROVED
+        )
         SplicePlanEntry.objects.create(plan=plan, tray=self.tray, fiber_a=self.fp1, fiber_b=self.fp2)
         result = apply_diff(plan)
         assert result["added"] == 1
@@ -228,16 +231,18 @@ class TestApplyDiff(TestCase):
         CableTermination.objects.create(cable=cable, cable_end="A", termination=self.fp3)
         CableTermination.objects.create(cable=cable, cable_end="B", termination=self.fp4)
 
-        plan = SplicePlan.objects.create(closure=self.closure, name="Remove Plan")
+        plan = SplicePlan.objects.create(
+            closure=self.closure, name="Remove Plan", status=SplicePlanStatusChoices.APPROVED
+        )
         result = apply_diff(plan)
         assert result["removed"] == 1
         assert not Cable.objects.filter(pk=cable.pk).exists()
 
-    def test_apply_does_not_change_status(self):
-        """apply_diff() no longer changes status — batch apply handles archiving."""
-        from netbox_fms.choices import SplicePlanStatusChoices
-
-        plan = SplicePlan.objects.create(closure=self.closure, name="Status Plan")
+    def test_apply_archives_plan(self):
+        """apply_diff() archives the plan after a successful apply (issue #111)."""
+        plan = SplicePlan.objects.create(
+            closure=self.closure, name="Status Plan", status=SplicePlanStatusChoices.APPROVED
+        )
         apply_diff(plan)
         plan.refresh_from_db()
-        assert plan.status == SplicePlanStatusChoices.DRAFT
+        assert plan.status == SplicePlanStatusChoices.ARCHIVED


### PR DESCRIPTION
## Summary
- The apply action for splice plans previously required only `change_spliceplan` and ignored plan status, so any draft could be applied straight to the live closure, bypassing the draft -> pending_approval -> approved workflow.
- Applying now requires the plan to be in approved status AND the caller to hold `approve_spliceplan`; a successful apply automatically archives the plan.
- The status gate lives in the service layer (`apply_diff()` raises `PlanNotApplicable`, mapped to HTTP 409 by the API view), so every apply path -- including the Pending Work batch apply -- shares one implementation. The Pending Work POST also gained the `approve_spliceplan` check and lost its duplicated archive block.

## Changes
- `netbox_fms/services.py`: `PlanNotApplicable` exception; status gate and auto-archive (clearing `cached_diff`, setting `diff_stale`) inside `apply_diff()`'s atomic block; docstring states the full plan-vs-live diff semantics.
- `netbox_fms/api/views.py`: `apply_plan` returns 403 without `approve_spliceplan` and 409 (via `PlanNotApplicable`) for non-approved plans.
- `netbox_fms/views.py`: Pending Work batch apply requires `approve_spliceplan`; duplicate archive logic removed in favor of the service.
- `tests/test_apply_approval_gating.py`: new regression suite (constrained ObjectPermission users, not superusers) covering draft/pending/archived rejection, 403 for change-only users, and the approved-apply-then-archive path.
- `tests/test_pending_work_apply.py`, `tests/test_services.py`, `tests/test_api.py`: aligned with the new gating; superseded superuser apply round-trip removed.
- `CHANGELOG.md`, `docs/user-guide/splice-planning.md`, `docs/developer/architecture.md`: gating, auto-archive, and full-diff apply semantics documented; FSM table gains the apply transition.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (548 passed, full suite)
- [x] New/changed behavior covered by tests (diff coverage 100%)
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (README, CHANGELOG, zensical pages)

## Related
Fixes #111
