### PR TITLE
fix(views): exclude splice jumpers from Fiber Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fiber Overview no longer lists the front-port jumper cables that applying a
+  splice plan creates. The cable table now shows only cables that terminate on
+  a rear port of the closure or that already carry a FiberCable, so splice
+  jumpers no longer appear as unlinked cables offering a "Link Topology"
+  button, and the Cables counter no longer counts them. The link-topology
+  endpoint also rejects cables outside the closure's fiber topology. Fixes #93.
 - The Slack Loops layer on the netbox-pathways interactive map now declares a
   `url_template`, so the map sidebar's detail pane shows a "View Details" link
   to the slack loop instance. Refs jsenecal/netbox-pathways#81.

--- a/docs/user-guide/device-fiber-overview.md
+++ b/docs/user-guide/device-fiber-overview.md
@@ -6,7 +6,10 @@ NetBox FMS injects a **Fiber Overview** tab on device detail pages (via `templat
 
 The Fiber Overview tab consolidates the following information for the selected device:
 
-- **Connected fiber cables** -- all FiberCable instances associated with the device, including cable type, strand count, and termination details.
+- **Connected fiber cables** -- the cables that form the device's fiber topology: those terminating on a rear port
+  of the device, plus any cable that already carries a FiberCable. Each row shows cable type, strand link counts,
+  and gland assignment. Splice jumpers -- the front-port-to-front-port cables created when a splice plan is
+  applied -- are not listed here; they belong to the splice editor view.
 - **Fiber strand status** -- a per-strand breakdown showing whether each strand is available, in use, or spliced.
 - **Associated splice plans** -- one or more SplicePlan entries that reference strands terminating at the device. A single closure may have multiple active plans from different teams or projects.
 - **Closure cable entry (gland) assignments** -- for closure-type devices, the mapping of cables to physical entry points on the enclosure.
@@ -32,7 +35,9 @@ Key capabilities:
 
 ## Link Topology Modal
 
-From the Fiber Overview tab, operators can link cable topology for cables connected to the device. This triggers the `link_cable_topology()` workflow, which:
+From the Fiber Overview tab, operators can link cable topology for cables that are part of the device's fiber
+topology (see above); cables outside it, such as splice jumpers, are rejected. This triggers the
+`link_cable_topology()` workflow, which:
 
 1. Creates a FiberCable from an existing `dcim.Cable`.
 2. Proposes FrontPort adoption or creation based on the cable type's strand configuration.

--- a/netbox_fms/api/views.py
+++ b/netbox_fms/api/views.py
@@ -57,7 +57,7 @@ from ..models import (
     TrayProfile,
     TubeAssignment,
 )
-from ..services import apply_diff, get_or_recompute_diff, import_live_state, protecting_nodes
+from ..services import apply_diff, device_cable_ids, get_or_recompute_diff, import_live_state, protecting_nodes
 from ..trace_hops import build_hops
 from .serializers import (
     BufferTubeSerializer,
@@ -641,13 +641,7 @@ class ClosureStrandsAPIView(APIView):
 
         # Find all FiberCables whose dcim.Cable terminates at this device
         # Get all cables connected to this device
-        cable_ids = (
-            CableTermination.objects.filter(
-                _device_id=device_id,
-            )
-            .values_list("cable_id", flat=True)
-            .distinct()
-        )
+        cable_ids = device_cable_ids(device_id)
 
         fiber_cables = (
             FiberCable.objects.restrict(user, "view")

--- a/netbox_fms/services.py
+++ b/netbox_fms/services.py
@@ -55,6 +55,42 @@ def _determine_cable_end(cable, device):
     return "A"
 
 
+def device_cable_ids(device_id):
+    """Return the ids of every dcim.Cable terminating on a device."""
+    return set(
+        CableTermination.objects.filter(_device_id=device_id)
+        .exclude(cable__isnull=True)
+        .values_list("cable_id", flat=True)
+    )
+
+
+def rear_port_cable_ids(device_id):
+    """Return the ids of the cables terminating on a device's rear ports."""
+    return set(
+        CableTermination.objects.filter(
+            termination_type=ContentType.objects.get_for_model(RearPort),
+            termination_id__in=RearPort.objects.filter(device_id=device_id).values("pk"),
+        ).values_list("cable_id", flat=True)
+    )
+
+
+def device_topology_cable_ids(device_id):
+    """Return the ids of the cables forming a closure's fiber topology.
+
+    A cable qualifies when it terminates on one of the device's rear ports,
+    or when it already carries a FiberCable. Splice jumpers, which join two
+    tray front ports of the same closure and never carry a FiberCable, are
+    excluded.
+    """
+    cable_ids = device_cable_ids(device_id)
+    if not cable_ids:
+        return cable_ids
+
+    rear_terminated = rear_port_cable_ids(device_id) & cable_ids
+    linked = set(FiberCable.objects.filter(cable_id__in=cable_ids).values_list("cable_id", flat=True))
+    return rear_terminated | linked
+
+
 def _provision_device_ports(fc, device, port_type, fk_field):
     """Create greenfield ports on a device for every strand of a FiberCable.
 

--- a/netbox_fms/signals.py
+++ b/netbox_fms/signals.py
@@ -21,23 +21,10 @@ class fms_portmapping_bypass:  # noqa: N801
 
 def _is_fms_managed_device(device_id):
     """Return True if the device has FMS-provisioned fiber ports."""
-    from dcim.models import CableTermination, RearPort
-    from django.contrib.contenttypes.models import ContentType
-
     from .models import FiberCable
+    from .services import rear_port_cable_ids
 
-    rp_ct = ContentType.objects.get_for_model(RearPort)
-    rp_ids = set(RearPort.objects.filter(device_id=device_id).values_list("pk", flat=True))
-    if not rp_ids:
-        return False
-
-    cable_ids = set(
-        CableTermination.objects.filter(
-            termination_type=rp_ct,
-            termination_id__in=rp_ids,
-        ).values_list("cable_id", flat=True)
-    )
-    return FiberCable.objects.filter(cable_id__in=cable_ids).exists()
+    return FiberCable.objects.filter(cable_id__in=rear_port_cable_ids(device_id)).exists()
 
 
 def _portmapping_pre_save(sender, instance, **kwargs):

--- a/netbox_fms/views.py
+++ b/netbox_fms/views.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
 from django.db.models import Count, Q
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -125,6 +125,8 @@ from .services import (
     apply_diff,
     create_closure_cable,
     create_splice_closure,
+    device_cable_ids,
+    device_topology_cable_ids,
     get_or_recompute_diff,
     import_live_state,
     link_cable_topology,
@@ -1870,23 +1872,13 @@ def _device_has_modules_or_fiber_cables(device):
     """Return True if device has modules (trays) or FiberCable terminations."""
     if device.modules.exists():
         return True
-    cable_ids = (
-        CableTermination.objects.filter(_device_id=device.pk)
-        .exclude(cable__isnull=True)
-        .values_list("cable_id", flat=True)
-        .distinct()
-    )
+    cable_ids = device_cable_ids(device.pk)
     return FiberCable.objects.filter(cable_id__in=cable_ids).exists()
 
 
 def _build_cable_rows(device):
     """Build context dicts for Fiber Overview, grouped by cable."""
-    cable_ids = (
-        CableTermination.objects.filter(_device_id=device.pk)
-        .exclude(cable__isnull=True)
-        .values_list("cable_id", flat=True)
-        .distinct()
-    )
+    cable_ids = device_topology_cable_ids(device.pk)
 
     cables = Cable.objects.filter(pk__in=cable_ids).order_by("pk")
     fc_by_cable = {
@@ -1940,12 +1932,7 @@ def _device_has_splice_plan_or_fiber_cables(device):
     """Return True if this device has a splice plan or FiberCable terminations."""
     if SplicePlan.objects.filter(closure=device).exists():
         return True
-    cable_ids = (
-        CableTermination.objects.filter(_device_id=device.pk)
-        .exclude(cable__isnull=True)
-        .values_list("cable_id", flat=True)
-        .distinct()
-    )
+    cable_ids = device_cable_ids(device.pk)
     return FiberCable.objects.filter(cable_id__in=cable_ids).exists()
 
 
@@ -2260,6 +2247,14 @@ class DevicePendingWorkView(generic.ObjectView):
         return redirect(device.get_absolute_url())
 
 
+def _get_closure_cable_or_404(device, cable_id):
+    """Fetch a cable only when it belongs to this closure's fiber topology."""
+    cable = get_object_or_404(Cable, pk=cable_id)
+    if cable.pk not in device_topology_cable_ids(device.pk):
+        raise Http404("Cable is not part of this device's fiber topology")
+    return cable
+
+
 class LinkTopologyView(LoginRequiredMixin, View):
     """Link a dcim.Cable to a FiberCableType — creates FiberCable and links strands."""
 
@@ -2269,7 +2264,7 @@ class LinkTopologyView(LoginRequiredMixin, View):
             return HttpResponse("Permission denied", status=403)
         device = get_object_or_404(Device, pk=pk)
         cable_id = request.GET.get("cable_id")
-        cable = get_object_or_404(Cable, pk=cable_id)
+        cable = _get_closure_cable_or_404(device, cable_id)
 
         rp_ct = ContentType.objects.get_for_model(RearPort)
         has_existing = CableTermination.objects.filter(
@@ -2296,9 +2291,9 @@ class LinkTopologyView(LoginRequiredMixin, View):
         if not request.user.has_perm("netbox_fms.add_fibercable"):
             return HttpResponse("Permission denied", status=403)
         device = get_object_or_404(Device, pk=pk)
+        cable = _get_closure_cable_or_404(device, request.POST.get("cable_id"))
 
         if request.POST.get("confirm_mapping"):
-            cable = get_object_or_404(Cable, pk=request.POST.get("cable_id"))
             fct = get_object_or_404(FiberCableType, pk=request.POST.get("fiber_cable_type_id"))
             port_mapping = {}
             for key, value in request.POST.items():
@@ -2312,7 +2307,6 @@ class LinkTopologyView(LoginRequiredMixin, View):
 
         form = LinkTopologyForm(request.POST)
         if not form.is_valid():
-            cable = get_object_or_404(Cable, pk=request.POST.get("cable_id"))
             return render(
                 request,
                 "netbox_fms/htmx/link_topology_modal.html",
@@ -2325,7 +2319,6 @@ class LinkTopologyView(LoginRequiredMixin, View):
                 },
             )
 
-        cable = get_object_or_404(Cable, pk=request.POST.get("cable_id"))
         fct = form.cleaned_data["fiber_cable_type"]
         port_type = form.cleaned_data.get("port_type") or "splice"
 

--- a/tests/test_fiber_overview.py
+++ b/tests/test_fiber_overview.py
@@ -1,11 +1,27 @@
-from dcim.models import Cable, Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+import pytest
+from dcim.models import (
+    Cable,
+    CableTermination,
+    Device,
+    DeviceRole,
+    DeviceType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+    RearPort,
+    Site,
+)
 from django.contrib.auth import get_user_model
+from django.http import Http404
 from django.test import TestCase
 
 User = get_user_model()
 
-from netbox_fms.models import ClosureCableEntry, FiberCable, FiberCableType
-from netbox_fms.views import _device_has_modules_or_fiber_cables
+from netbox_fms.models import ClosureCableEntry, FiberCable, FiberCableType, SplicePlan, SplicePlanEntry
+from netbox_fms.services import apply_diff, create_closure_cable
+from netbox_fms.views import _build_cable_rows, _device_has_modules_or_fiber_cables, _get_closure_cable_or_404
+from tests.conftest import make_closure_with_tray
 
 
 class TestFiberOverviewTabVisibility(TestCase):
@@ -141,3 +157,64 @@ class TestNavigationCleanup(TestCase):
         assert "Fiber Cables" in link_texts
         assert "Splice Projects" in link_texts
         assert "Splice Plans" in link_texts
+
+
+class TestFiberOverviewCableRows(TestCase):
+    """Fiber Overview lists only closure topology cables, not splice jumpers (issue #93)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        rig = make_closure_with_tray("FO93", port_count=3)
+        cls.closure = rig.closure
+        cls.tray = rig.tray
+        cls.fp1, cls.fp2, cls.fp3 = rig.ports
+        far_end = Device.objects.create(name="FO93-Far", site=rig.site, device_type=rig.device_type, role=rig.role)
+        cls.fct = FiberCableType.objects.create(
+            manufacturer=rig.mfr,
+            model="FO93-TB6",
+            construction="tight_buffer",
+            strand_count=6,
+        )
+        cls.fiber_cable, _ = create_closure_cable(
+            device_a=cls.closure,
+            device_b=far_end,
+            fiber_cable_type=cls.fct,
+        )
+        cls.trunk = cls.fiber_cable.cable
+
+        # Rear-port cable with no FiberCable yet: the row that must keep its
+        # "Link Topology" button.
+        rear_port = RearPort.objects.create(device=cls.closure, name="FO93-RP-Bare", type="splice", positions=12)
+        cls.bare = Cable.objects.create()
+        CableTermination.objects.create(cable=cls.bare, cable_end="A", termination=rear_port)
+
+        # FiberCable attached to a cable that reaches the closure only through a
+        # front port -- the shape the form, import, and API paths allow.
+        cls.fp_cable = Cable.objects.create()
+        CableTermination.objects.create(cable=cls.fp_cable, cable_end="A", termination=cls.fp3)
+        cls.fp_fiber_cable = FiberCable.objects.create(cable=cls.fp_cable, fiber_cable_type=cls.fct)
+
+        plan = SplicePlan.objects.create(closure=cls.closure, name="FO93 Plan")
+        SplicePlanEntry.objects.create(plan=plan, tray=cls.tray, fiber_a=cls.fp1, fiber_b=cls.fp2)
+        assert apply_diff(plan)["added"] == 1
+        cls.jumper = Cable.objects.exclude(pk__in=[cls.trunk.pk, cls.bare.pk, cls.fp_cable.pk]).get()
+
+    def _rows_by_cable_pk(self):
+        return {row["cable"].pk: row for row in _build_cable_rows(self.closure)}
+
+    def test_front_port_jumper_excluded(self):
+        assert self.jumper.pk not in self._rows_by_cable_pk()
+
+    def test_rear_port_cables_still_listed(self):
+        rows = self._rows_by_cable_pk()
+        assert rows[self.trunk.pk]["fiber_cable"] == self.fiber_cable
+        assert rows[self.bare.pk]["fiber_cable"] is None
+
+    def test_fiber_cable_on_non_rear_port_listed(self):
+        rows = self._rows_by_cable_pk()
+        assert rows[self.fp_cable.pk]["fiber_cable"] == self.fp_fiber_cable
+
+    def test_link_topology_guard_rejects_cable_outside_topology(self):
+        assert _get_closure_cable_or_404(self.closure, self.bare.pk) == self.bare
+        with pytest.raises(Http404):
+            _get_closure_cable_or_404(self.closure, self.jumper.pk)

--- a/tests/test_link_topology.py
+++ b/tests/test_link_topology.py
@@ -1,5 +1,5 @@
 import pytest
-from dcim.models import Cable, Device, DeviceRole, DeviceType, Manufacturer, Site
+from dcim.models import Cable, CableTermination, Device, DeviceRole, DeviceType, Manufacturer, RearPort, Site
 
 from netbox_fms.models import BufferTubeTemplate, FiberCableType, RibbonTemplate
 
@@ -255,7 +255,6 @@ class TestLinkCableTopologyGreenfield:
                 fiber_count=12,
             )
         fc, warnings = link_cable_topology(cable, fct, device)
-        from dcim.models import RearPort
 
         assert RearPort.objects.filter(device=device).count() == 4
 
@@ -268,7 +267,6 @@ class TestLinkCableTopologyGreenfield:
             construction="tight_buffer",
         )
         fc, warnings = link_cable_topology(cable, fct, device)
-        from dcim.models import RearPort
 
         rps = RearPort.objects.filter(device=device)
         assert rps.count() == 1
@@ -370,7 +368,6 @@ class TestLinkCableTopologyAdopt:
         mapping = {i: fps[i - 1].pk for i in range(1, 13)}
         fc, warnings = link_cable_topology(cable, fct, device, port_mapping=mapping)
         assert fc.fiber_strands.filter(front_port_a__isnull=False).count() == 12
-        from dcim.models import RearPort
 
         assert RearPort.objects.filter(device=device).count() == 1  # no new RearPorts
 
@@ -433,7 +430,6 @@ class TestLinkCableTopologyAdopt:
 
         fc, warnings = link_cable_topology(cable, fct, device, port_mapping=exc_info.value.proposed_mapping)
         assert fc.fiber_strands.filter(front_port_a__isnull=False).count() == 48
-        from dcim.models import RearPort
 
         assert RearPort.objects.filter(device=device).count() == 4  # no new RearPorts
 
@@ -448,7 +444,9 @@ class TestLinkTopologyView:
         dt = DeviceType.objects.create(manufacturer=mfr, model="LTV-Closure", slug="ltv-closure")
         role = DeviceRole.objects.create(name="LTV-Role", slug="ltv-role")
         device = Device.objects.create(name="LTV-Device", site=site, device_type=dt, role=role)
+        rear_port = RearPort.objects.create(device=device, name="LTV-RP", type="splice", positions=12)
         cable = Cable.objects.create()
+        CableTermination.objects.create(cable=cable, cable_end="A", termination=rear_port)
         User = get_user_model()
         user = User.objects.create_superuser("ltv-admin", "ltv@test.com", "password")
         client.force_login(user)
@@ -599,8 +597,6 @@ class TestCableTerminationConnectorPositions:
                 fiber_count=12,
             )
         fc, warnings = link_cable_topology(cable, fct, device)
-
-        from dcim.models import RearPort
 
         rps = RearPort.objects.filter(device=device).order_by("name")
         for i, rp in enumerate(rps, start=1):


### PR DESCRIPTION
## Summary

- The Fiber Overview tab listed every cable terminating on the closure, so the front-port jumper cables created by applying a splice plan appeared as unlinked cables with a "Link Topology" button. Clicking it welded a third termination plus new rear/front ports onto the jumper.
- The cable table now lists only cables that form the closure's fiber topology: terminated on a rear port of the device, or already carrying a FiberCable.
- `LinkTopologyView` enforces the same predicate server-side, so a stale page or a crafted `cable_id` cannot reach the provisioning path.

## Changes

- `netbox_fms/services.py`: new `device_cable_ids()`, `rear_port_cable_ids()`, and `device_topology_cable_ids()` helpers.
- `netbox_fms/views.py`: `_build_cable_rows()` uses the topology-filtered helper; the two tab-visibility predicates use the unfiltered one (behavior unchanged, de-duplication only); new `_get_closure_cable_or_404()` guards the cable fetch in `LinkTopologyView`.
- `netbox_fms/signals.py`: `_is_fms_managed_device()` now shares `rear_port_cable_ids()` (19 lines to 5).
- `netbox_fms/api/views.py`: closure-strands endpoint uses the shared helper; no behavior change.
- `tests/test_fiber_overview.py`: regression tests reproducing the reported scenario through `apply_diff()`.
- `tests/test_link_topology.py`: modal fixture cable is now terminated on a rear port; removed five redundant local imports.
- `CHANGELOG.md`, `docs/user-guide/device-fiber-overview.md`: document the new rule.

## Predicate

A cable belongs to the closure's topology when it terminates on a **rear port of that device** OR it **already carries a FiberCable**.

The second clause is deliberate. Strict rear-port-only would silently hide FiberCables created through the model form, CSV import, or the REST API, none of which guarantee a rear-port termination. Splice jumpers satisfy neither clause: they join two tray front ports and never carry a FiberCable.

## Behavior narrowing (intentional)

Cables reaching the closure only through an interface or a front port are no longer listed or linkable from this tab. That is what the issue asks for. A consequence is that the greenfield branch of `link_cable_topology()` is no longer reachable from Fiber Overview -- every listed cable either has rear ports (adopt path) or already has a FiberCable (button hidden). The cable detail page still offers the link action. `stats["cable_count"]` drops by the jumper count; the fiber-cable and strand counters are unaffected.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally -- 546 passed
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG, zensical user guide)

Diff coverage is 96% against a project average of 80% (`services.py`, `signals.py`, `api/views.py` all 100%). The single uncovered line is the guard call in `LinkTopologyView.post`; covering it would require a view-level POST test, which this repo's test-scope rules exclude, and it was equally uncovered before this change.

Verification note: do not reproduce against `create_sample_data` output -- it builds jumper terminations with `bulk_create`, which leaves `CableTermination._device` NULL, so those jumpers never appeared in the overview. Reproduce through `apply_diff()`, as the regression fixture does.

## Related

Fixes #93
