### PR TITLE
feat(forms): scope port and cable dropdowns to their parent devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the saved ports. Previously every front port in the database was
   rendered into the page, which made the form unusable when port names
   repeat across devices and extremely slow on large databases. (#137)
+- Splice plan entry form: plan, tray, and both fiber dropdowns now chain
+  off a new Closure selector field (back-filled from the plan when
+  editing), and Fiber A is additionally narrowed to the selected tray's
+  ports, mirroring the model's own validation rules. Fiber options show
+  their parent device.
+- Fiber cable form: a new optional Device selector narrows the cable
+  dropdown to cables terminated at that device.
+- Closure pickers on the splice plan, closure cable entry, and tube
+  assignment forms now offer the advanced device selector modal.
 
 ## [0.3.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fiber circuit path form: origin and destination are now API-backed
+  dropdowns scoped by new Origin Device / Destination Device selector
+  fields, matching the NetBox cable connection form. Each port option
+  shows its parent device, and editing a path preselects the devices
+  from the saved ports. Previously every front port in the database was
+  rendered into the page, which made the form unusable when port names
+  repeat across devices and extremely slow on large databases. (#137)
+
 ## [0.3.0] - 2026-08-25
 
 ### Added

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -515,7 +515,18 @@ class CableElementTemplateBulkEditForm(NetBoxModelBulkEditForm):
 class FiberCableForm(NetBoxModelForm):
     """Form for creating/editing a FiberCable."""
 
-    cable = DynamicModelChoiceField(queryset=Cable.objects.all(), label=_("Cable"))
+    device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        selector=True,
+        label=_("Device"),
+        help_text=_("Show only cables terminated at this device."),
+    )
+    cable = DynamicModelChoiceField(
+        queryset=Cable.objects.all(),
+        label=_("Cable"),
+        query_params={"device_id": "$device"},
+    )
     fiber_cable_type = DynamicModelChoiceField(
         queryset=FiberCableType.objects.all(),
         label=_("Fiber Cable Type"),
@@ -529,7 +540,7 @@ class FiberCableForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        FieldSet("cable", "fiber_cable_type", name=_("Fiber Cable")),
+        FieldSet("device", "cable", "fiber_cable_type", name=_("Fiber Cable")),
         FieldSet("serial_number", "install_date", "installed_by", name=_("Identification")),
         FieldSet("start_mark", "end_mark", name=_("Sheath Marks")),
         FieldSet("notes", "tags", name=_("Additional")),
@@ -669,7 +680,7 @@ class SpliceProjectFilterForm(NetBoxModelFilterSetForm):
 class SplicePlanForm(NetBoxModelForm):
     """Form for creating/editing a SplicePlan."""
 
-    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"))
+    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"), selector=True)
     project = DynamicModelChoiceField(
         queryset=SpliceProject.objects.all(),
         required=False,
@@ -751,13 +762,38 @@ class SplicePlanFilterForm(NetBoxModelFilterSetForm):
 class SplicePlanEntryForm(NetBoxModelForm):
     """Form for creating/editing a SplicePlanEntry."""
 
-    plan = DynamicModelChoiceField(queryset=SplicePlan.objects.all(), label=_("Plan"))
-    tray = DynamicModelChoiceField(queryset=Module.objects.all(), label=_("Tray"))
-    fiber_a = DynamicModelChoiceField(queryset=FrontPort.objects.all(), label=_("Fiber A"))
-    fiber_b = DynamicModelChoiceField(queryset=FrontPort.objects.all(), label=_("Fiber B"))
+    closure = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        selector=True,
+        label=_("Closure"),
+        initial_params={"splice_plans": "$plan"},
+    )
+    plan = DynamicModelChoiceField(
+        queryset=SplicePlan.objects.all(),
+        label=_("Plan"),
+        query_params={"closure_id": "$closure"},
+    )
+    tray = DynamicModelChoiceField(
+        queryset=Module.objects.all(),
+        label=_("Tray"),
+        query_params={"device_id": "$closure"},
+    )
+    fiber_a = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label=_("Fiber A"),
+        context={"parent": "device"},
+        query_params={"device_id": "$closure", "module_id": "$tray"},
+    )
+    fiber_b = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label=_("Fiber B"),
+        context={"parent": "device"},
+        query_params={"device_id": "$closure"},
+    )
 
     fieldsets = (
-        FieldSet("plan", "tray", "fiber_a", "fiber_b", name=_("Splice Entry")),
+        FieldSet("closure", "plan", "tray", "fiber_a", "fiber_b", name=_("Splice Entry")),
         FieldSet("notes", name=_("Notes")),
         FieldSet("tags", name=_("Additional")),
     )
@@ -792,7 +828,7 @@ class SplicePlanEntryFilterForm(NetBoxModelFilterSetForm):
 class ClosureCableEntryForm(NetBoxModelForm):
     """Form for creating/editing a ClosureCableEntry."""
 
-    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"))
+    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"), selector=True)
     fiber_cable = DynamicModelChoiceField(
         queryset=FiberCable.objects.all(),
         label=_("Fiber Cable"),
@@ -1255,7 +1291,7 @@ def _check_tube_assignment_conflicts(form):
 class TubeAssignmentForm(NetBoxModelForm):
     """Form for creating/editing a TubeAssignment."""
 
-    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"))
+    closure = DynamicModelChoiceField(queryset=Device.objects.all(), label=_("Closure"), selector=True)
     tray = DynamicModelChoiceField(
         queryset=Module.objects.all(), label=_("Tray"), query_params={"device_id": "$closure"}
     )

--- a/netbox_fms/forms.py
+++ b/netbox_fms/forms.py
@@ -997,9 +997,44 @@ class FiberCircuitPathForm(NetBoxModelForm):
         queryset=FiberCircuit.objects.all(),
         label=_("Circuit"),
     )
+    origin_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        selector=True,
+        label=_("Origin Device"),
+        initial_params={"frontports": "$origin"},
+    )
+    origin = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label=_("Origin"),
+        context={"parent": "device"},
+        query_params={"device_id": "$origin_device"},
+    )
+    destination_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        selector=True,
+        label=_("Destination Device"),
+        initial_params={"frontports": "$destination"},
+    )
+    destination = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        required=False,
+        label=_("Destination"),
+        context={"parent": "device"},
+        query_params={"device_id": "$destination_device"},
+    )
 
     fieldsets = (
-        FieldSet("circuit", "position", "origin", "destination", name=_("Path")),
+        FieldSet(
+            "circuit",
+            "position",
+            "origin_device",
+            "origin",
+            "destination_device",
+            "destination",
+            name=_("Path"),
+        ),
         FieldSet("actual_loss_db", "wavelength_nm", name=_("Optical Parameters")),
         FieldSet("tags", name=_("Additional")),
     )

--- a/tests/test_fiber_circuit_path_form.py
+++ b/tests/test_fiber_circuit_path_form.py
@@ -1,0 +1,39 @@
+"""Tests for device-scoped port selection on the circuit path form (issue #137)."""
+
+from django.test import TestCase
+from utilities.forms.fields import DynamicModelChoiceField
+
+from netbox_fms.forms import FiberCircuitPathForm
+
+
+class TestFiberCircuitPathFormPortSelection(TestCase):
+    """FiberCircuitPathForm scopes origin/destination ports to a chosen device (#137).
+
+    The origin and destination fields used to be plain ModelChoiceFields that
+    rendered every FrontPort in the database into the page, which made the form
+    unusable (duplicate port names across devices) and unbearably slow with
+    thousands of ports.
+    """
+
+    def test_origin_is_api_backed_and_scoped_to_origin_device(self):
+        field = FiberCircuitPathForm().fields["origin"]
+        assert isinstance(field, DynamicModelChoiceField)
+        assert field.query_params == {"device_id": "$origin_device"}
+        assert field.context == {"parent": "device"}
+
+    def test_destination_is_api_backed_and_scoped_to_destination_device(self):
+        field = FiberCircuitPathForm().fields["destination"]
+        assert isinstance(field, DynamicModelChoiceField)
+        assert field.query_params == {"device_id": "$destination_device"}
+        assert field.context == {"parent": "device"}
+        assert field.required is False
+
+    def test_device_selectors_back_fill_from_saved_ports(self):
+        form = FiberCircuitPathForm()
+        origin_device = form.fields["origin_device"]
+        destination_device = form.fields["destination_device"]
+        for field in (origin_device, destination_device):
+            assert field.selector is True
+            assert field.required is False
+        assert origin_device.initial_params == {"frontports": "$origin"}
+        assert destination_device.initial_params == {"frontports": "$destination"}

--- a/tests/test_form_device_scoping.py
+++ b/tests/test_form_device_scoping.py
@@ -1,0 +1,62 @@
+"""Tests for device-scoped selection on splice and cable forms (follow-up to issue #137)."""
+
+from django.test import TestCase
+
+from netbox_fms.forms import (
+    ClosureCableEntryForm,
+    FiberCableForm,
+    SplicePlanEntryForm,
+    SplicePlanForm,
+    TubeAssignmentForm,
+)
+
+
+class TestSplicePlanEntryFormScoping(TestCase):
+    """SplicePlanEntryForm scopes plan, tray, and fibers to a chosen closure.
+
+    The tray field used to search every Module in NetBox and the fiber
+    fields every FrontPort, even though SplicePlanEntry.clean() rejects
+    any port outside the plan's closure and any tray other than fiber_a's
+    parent module.
+    """
+
+    def test_closure_selector_back_fills_from_plan(self):
+        field = SplicePlanEntryForm().fields["closure"]
+        assert field.selector is True
+        assert field.required is False
+        assert field.initial_params == {"splice_plans": "$plan"}
+
+    def test_plan_tray_and_fibers_chain_on_closure(self):
+        form = SplicePlanEntryForm()
+        assert form.fields["plan"].query_params == {"closure_id": "$closure"}
+        assert form.fields["tray"].query_params == {"device_id": "$closure"}
+        assert form.fields["fiber_b"].query_params == {"device_id": "$closure"}
+
+    def test_fiber_a_also_chains_on_tray(self):
+        """clean() requires tray == fiber_a.module, so the dropdown mirrors it."""
+        field = SplicePlanEntryForm().fields["fiber_a"]
+        assert field.query_params == {"device_id": "$closure", "module_id": "$tray"}
+
+    def test_fibers_show_parent_device(self):
+        form = SplicePlanEntryForm()
+        assert form.fields["fiber_a"].context == {"parent": "device"}
+        assert form.fields["fiber_b"].context == {"parent": "device"}
+
+
+class TestFiberCableFormScoping(TestCase):
+    """FiberCableForm offers an optional device to narrow the cable dropdown."""
+
+    def test_cable_chains_on_device(self):
+        form = FiberCableForm()
+        device = form.fields["device"]
+        assert device.selector is True
+        assert device.required is False
+        assert form.fields["cable"].query_params == {"device_id": "$device"}
+
+
+class TestClosureFieldsUseSelector(TestCase):
+    """Closure device pickers offer the advanced selector modal."""
+
+    def test_closure_fields_have_selector(self):
+        for form_cls in (SplicePlanForm, ClosureCableEntryForm, TubeAssignmentForm):
+            assert form_cls().fields["closure"].selector is True, form_cls.__name__


### PR DESCRIPTION
## Summary
- Fix the fiber circuit path form rendering every FrontPort in the database into the page: origin and destination are now API-backed dropdowns scoped by Origin Device / Destination Device selector fields, mirroring the NetBox cable connection form (fixes the unusable duplicate-name dropdowns and the multi-minute page load from #137).
- Extend the same device-scoping pattern to the splice plan entry form (closure anchor chaining plan, tray, and both fibers -- fiber_a additionally narrowed to the tray, matching SplicePlanEntry.clean()) and the fiber cable form (optional device anchor for the cable dropdown).
- Add the advanced device selector modal (selector=True) to the remaining bare closure pickers.

## Changes
- netbox_fms/forms.py: FiberCircuitPathForm origin/destination converted to DynamicModelChoiceFields chained on new device anchor fields, with parent-device context and initial_params back-fill on edit.
- netbox_fms/forms.py: SplicePlanEntryForm gains a closure anchor; plan/tray/fiber_a/fiber_b chain on it; FiberCableForm gains an optional device anchor; SplicePlanForm, ClosureCableEntryForm, and TubeAssignmentForm closure fields gain selector=True.
- tests/test_fiber_circuit_path_form.py: regression tests for the #137 field wiring.
- tests/test_form_device_scoping.py: wiring tests for the splice/cable scoping and selector flags.
- CHANGELOG.md: entries under Unreleased.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` (`make test PLUGIN=netbox-fms`) passes locally (590 passed)
- [x] New/changed behavior covered by tests (diff coverage 100% vs origin/main)
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG; README/zensical describe the data model, not form mechanics)

## Related
Fixes: #137
