### PR TITLE
chore: add NetBox 4.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           - "4.5.10"
           # renovate: datasource=github-releases depName=netbox-community/netbox
           - "4.6.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.7.0"
     services:
       postgres:
         image: postgis/postgis:17-3.4
@@ -148,7 +150,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=netbox_fms --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.5.')
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.7.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI now tests against the latest NetBox 4.5 and 4.6 releases (4.5.10
   and 4.6.10, previously 4.5.4 and 4.5.5); the README compatibility
   matrix reflects NetBox 4.5-4.6 support.
+- CI now also tests against NetBox 4.7.0; the README compatibility
+  matrix reflects NetBox 4.5-4.7 support. The cable-profile monkey
+  patches in `monkey_patches.py` (CableProfileChoices.CHOICES/
+  ._choices, the Cable `profile` field's choices, and
+  Cable.profile_class) were verified against a running NetBox 4.7.0 /
+  Django 6.1 environment; no source changes were needed.
 
 ## [0.3.0] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Define fiber cable construction as reusable blueprints, auto-instantiate compone
 
 | Plugin version | NetBox version | Python    |
 |----------------|----------------|-----------|
-| 0.3.x          | 4.5-4.6        | 3.12-3.14 |
+| 0.3.x          | 4.5-4.7        | 3.12-3.14 |
 
 ## Installation
 

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["netbox-community/netbox"],
       "matchCurrentValue": "/^4\\.6\\./",
       "allowedVersions": "/^4\\.6\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.7\\./",
+      "allowedVersions": "/^4\\.7\\./"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Adds NetBox 4.7.0 to the CI test matrix (keeping 4.5.10 and 4.6.10) and moves the Codecov upload to the 4.7 lane; adds the Renovate per-minor lane for 4.7.
- Declares NetBox 4.7 support in the CHANGELOG and README compatibility matrix.
- The cable-profile monkey patches were verified against a running NetBox 4.7.0 / Django 6.1 instance: CableProfileChoices.CHOICES/._choices, the Cable profile field choices, and Cable.profile_class all still carry the fms fiber profile groups. No source changes were needed.

## Changes
- .github/workflows/ci.yml: renovate-annotated 4.7.0 matrix entry; codecov condition anchored to startsWith '4.7.'
- renovate.json: allowedVersions lane for /^4\.7\./
- CHANGELOG.md, README.md: 4.7 support declared

## Testing
- [x] Monkey-patch smoke test on live NetBox 4.7.0 (import + choices assertions, all passed)
- [x] Workflow YAML and renovate.json parse cleanly
- [ ] `ruff check` / `ruff format --check` -- not applicable (no Python touched)
- [ ] Full suite on 4.7 -- left to this PR's CI run (new 4.7.0 lane)

## Related
Closes #141
