### PR TITLE
ci: skip test runs for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,28 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'renovate.json'
+      - '.github/dependabot.yml'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/release-drafter.yml'
+      - '.github/workflows/pr-title.yml'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'renovate.json'
+      - '.github/dependabot.yml'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/publish.yml'
+      - '.github/workflows/release-drafter.yml'
+      - '.github/workflows/pr-title.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds the canonical paths-ignore set (markdown, docs/, LICENSE, renovate.json, dependabot config, self-triggered workflow files) to both the pull_request and push triggers of ci.yml, matching every other owned plugin. Docs-only changes no longer spend nine test-matrix jobs.

## Changes
- .github/workflows/ci.yml: paths-ignore on both triggers

## Testing
- [x] Workflow YAML parses cleanly
- [ ] This PR itself must still trigger CI (ci.yml is not an ignored path)